### PR TITLE
Create initrd as a rootfs for Unikraft

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ platforms:                                      # [3] The target unikernel platf
 rootfs:                                         # [4] (Optional) Specifies the rootfs of the unikernel.
   from: local                                   # [4a] (Optional) The source of the initrd.
   path: initrd                                  # [4b] (Required if from is not scratch) The path in the source, where a prebuilt rootfs file resides.
+  include:                                      # [4c] (Optional) A list of files to include in the rootfs
+    - src:dst
 
 kernel:                                         # [5] Specify a prebuilt kernel to use
   from: local                                   # [5a] Specify the source of an existing prebuilt kernel.
@@ -135,13 +137,20 @@ The fields of `bunnyfile` in more details:
         [hvt](https://github.com/Solo5/solo5),
         [Spt](https://github.com/Solo5/solo5).
     3d. The architecture of the host where the unikernel will run.
-4. (Optional) The rootfs of the unikernel. For the time being, only prebuilt rootfs files are supported and `bunny` will package everything as an OCI image with the respective annotations for [urunc](https://github.com/Solo5/solo5).
+4. (Optional) The rootfs of the unikernel. Currently, `bunny` is able to either
+   package existing rootfs files, or to build the rootfs in the form of an
+   initrd.
     4a. The source where an existing rootfs file is stored. Current supported
-        values are: local, meaning that the file resides somewhere locally.
-    4b. This field is required, if from is specified and has a value other than
-        `scratch`.The path in the source where the existing rootfs file resides. In the
+        values are: i) `scratch`, meaning that the rootfs should get built from
+        scratch, and ii) `local`, meaning that an existing rootfs file resides
+        somewhere locally. The default value is `scratch`.
+    4b. The path for the file in the aformentioned source. This field is
+        required, if `from` has a value other than `scratch`..In the
         case where the `from` field has the value `local`, then the `path` should
         be relative to the build context.
+    4c. A list of files to include in the rootfs. This field takes effect only
+        when the `from` field has the value `scratch`. The files can be defined
+        in the following format: `- <path_in_the_build_context>:<path_inside_rootfs>`. The `<path_inside_rootfs>` can be omitted and then the same path as the one in `<path_in_the_build_context>` will be used.
 5. Information regarding an existing prebuilt kernel to use. For the time
    being, `bunny` supports only prebuilt unikernels and `bunny` will package
    everything as an OCI image with the respective annotations for

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -154,13 +154,13 @@ func bunnyBuilder(ctx context.Context, c client.Client) (*client.Result, error) 
 	}
 
 	// Parse packaging/building instructions
-	packInst, err := hops.ParseFile(fileBytes)
+	packInst, err := hops.ParseFile(fileBytes, buildContextName)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing building instructions: %v", err)
 	}
 
 	// Create the LLB definiton of packing the final image
-	dt, err := hops.PackLLB(*packInst, buildContextName)
+	dt, err := hops.PackLLB(*packInst)
 	if err != nil {
 		return nil, fmt.Errorf("Could not create LLB definition: %v", err)
 	}
@@ -218,14 +218,14 @@ func main() {
 	}
 
 	// Parse file with packaging/building instructions
-	packInst, err = hops.ParseFile(CntrFileContent)
+	packInst, err = hops.ParseFile(CntrFileContent, buildContextName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: Could not parse building instructions: %v\n", err)
 		os.Exit(1)
 	}
 
 	// Create the LLB definition of packing the final image
-	dt, err := hops.PackLLB(*packInst, buildContextName)
+	dt, err := hops.PackLLB(*packInst)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: Could not create LLB definition: %v\n", err)
 		os.Exit(1)

--- a/examples/CHTTP_Unikraft.md
+++ b/examples/CHTTP_Unikraft.md
@@ -1,0 +1,131 @@
+# Creating the initrd and packaging a Unikraft unikernel with `bunny`
+
+For this example, we will use the [C HTTP Web
+Server](https://github.com/unikraft/catalog/tree/main/examples/http-c) example
+in Unikraft's catalog. To build the unikernel, we mainly need to:
+1. Build the C HTTP server
+2. Create the initrd for Unikraft
+3. Use the latest base image of [Unikraft's catalog](https://github.com/unikraft/catalog) and package everything together.
+
+We will perform the above steps with and without `bunnyfile` to showcase how we can
+use `bunny`.
+
+## Without `bunnyfile`
+
+### Step 1: Building the C HTTP Server
+
+We will build the C application as a static binary.
+
+```
+gcc -static-pie -o chttp http_server.c
+```
+
+### Step 2: Create the initrd file for Unikraft
+
+We will create the initrd file for Unikraft, using the `bsdcpio` command:
+
+```
+mkdir rootfs
+mv chttp rootfs/
+cd rootfs
+find -depth -print | tac | bsdcpio -o --format newc > ../rootfs.cpio
+cd ../
+```
+
+Alternatively, we can use [kraftkit](https://github.com/unikraft/kraftkit) and
+inside the `examples/http-c` directory of Unikraft's catalog run:
+
+```
+kraft build
+```
+
+Check the output of the command for the path of the generated cpio file. Usually
+the path is `.unikraft/build/initramfs-x86_64.cpio`.
+
+> **NOTE**: For simplicity we will use the rootfs.cpio as the filename of the cpio.
+
+### Step 3: Package everything together.
+
+To package everything together, we can use the following `Containerfile`:
+
+```
+#syntax=harbor.nbfc.io/nubificus/bunny:latest
+FROM unikraft.org/base:latest
+
+LABEL com.urunc.unikernel.binary="/unikraft/bin/kernel"
+LABEL "com.urunc.unikernel.cmdline"="/chttp"
+LABEL "com.urunc.unikernel.unikernelType"="unikraft"
+LABEL "com.urunc.unikernel.hypervisor"="qemu"
+```
+
+## Using a `bunnyfile`
+
+Due to the capabilities of `bunny`, if we choose to use a `bunnyfile`, the steps
+2 and 3 can be performed in one run. Therefore, we build the C application in
+the same way as in the [first step](#Step-1:-Building-the-C-HTTP-Server)
+previously. Then, we can define the `bunnyfile` as:
+
+```
+#syntax=harbor.nbfc.io/nubificus/bunny:latest
+version: v0.1
+
+platforms:
+  framework: unikraft
+  version: 0.18.0
+  monitor: qemu
+  architecture: x86
+
+rootfs:
+  from: scratch
+  include:
+    - chttp:/chttp
+
+kernel:
+  from: unikraft.org/base:latest
+  path: /unikraft/bin/kernel
+
+cmdline: /chttp
+```
+
+With the above bunnyfile`, `bunny` will build the rootfs of Unikraft as a cpio
+file with the contents we define in the `include` field of `rootfs`.
+
+## Building the image with bunny as buildkit's frontend
+
+In the case, we want to build the image directly through docker, using `bunny`
+as a frontend for buildkit, we can simply run the following command:
+
+```
+docker build -f bunnyfile -t harbor.nbfc.io/nubificus/urunc/nginx-unikraft-qemu:test .
+```
+
+The image will get loaded in the local docker registry. If we want to build with
+[annotations](#https://github.com/nubificus/bunny/docs/annotations.md), then the
+command should change to the following:
+
+```
+docker buildx build --builder=<container-build-driver>  --output "type=image,oci-mediatypes=true" -f bunnyfile -t harbor.nbfc.io/nubificus/urunc/nginx-unikraft-qemu:test --push=true .
+```
+The image will get pushed in the registry.
+
+## Building the image with `bunny` and buildctl
+
+In the case we want to use `bunny` and produce a LLB to pass it to buildctl,
+We can build the image with the following command:
+
+```
+./bunny -LLB -f bunnyfile | sudo buildctl build ... --local context=${PWD} --output type=docker,name=harbor.nbfc.io/nubificus/urunc/nginx-unikraft-qemu:test | sudo docker load
+```
+
+The image will get loaded in the local docker registry. If we want to build with
+[annotations](#https://github.com/nubificus/bunny/docs/annotations.md), then the
+command should change to the following:
+
+```
+./bunny --LLB -f bunnyfile | sudo buildctl build ... --local context=${PWD} --output "type=image,name=harbor.nbfc.io/nubificus/urunc/nginx-unikraft-qemu:test,oci-mediatypes=true,push=true"
+```
+
+The image will get pushed in the registry.
+
+> **NOTE**: In the above commands by simply replacing bunnyfile with
+> Containerfile and simply switch from one to the other file formats.

--- a/examples/Nginx_Unikraft.md
+++ b/examples/Nginx_Unikraft.md
@@ -7,7 +7,8 @@ execute with `bunny`. The respective `Containerfile` that we would use with
 [pun](https://github.com/nubificus/pun) would be:
 
 ```
-#syntax=harbor.nbfc.io/nubificus/bunny:latest FROM unikraft.org/nginx:1.15
+#syntax=harbor.nbfc.io/nubificus/bunny:latest
+FROM unikraft.org/nginx:1.15
 
 LABEL com.urunc.unikernel.binary="/unikraft/bin/kernel"
 LABEL "com.urunc.unikernel.cmdline"="nginx -c /nginx/conf/nginx.conf"
@@ -41,7 +42,7 @@ In the case, we want to build the image directly through docker, using `bunny`
 as a frontend for buildkit, we can simply run the following command:
 
 ```
-docker build -f Containerfile -t harbor.nbfc.io/nubificus/urunc/nginx-unikraft-qemu:test .
+docker build -f bunnyfile -t harbor.nbfc.io/nubificus/urunc/nginx-unikraft-qemu:test .
 ```
 
 The image will get loaded in the local docker registry. If we want to build with
@@ -49,7 +50,7 @@ The image will get loaded in the local docker registry. If we want to build with
 command should change to the following:
 
 ```
-docker buildx build --builder=<container-build-driver>  --output "type=image,oci-mediatypes=true" -f Containerfile -t harbor.nbfc.io/nubificus/urunc/nginx-unikraft-qemu:test --push=true .
+docker buildx build --builder=<container-build-driver>  --output "type=image,oci-mediatypes=true" -f bunnyfile -t harbor.nbfc.io/nubificus/urunc/nginx-unikraft-qemu:test --push=true .
 ```
 
 The image will get pushed in the registry.
@@ -60,7 +61,7 @@ In the case we want to use `bunny` and produce a LLB to pass it to buildctl,
 We can build the image with the following command:
 
 ```
-./bunny -LLB -f Containerfile | sudo buildctl build ... --local context=${PWD} --output type=docker,name=harbor.nbfc.io/nubificus/urunc/nginx-unikraft-qemu:test | sudo docker load
+./bunny -LLB -f bunnyfile | sudo buildctl build ... --local context=${PWD} --output type=docker,name=harbor.nbfc.io/nubificus/urunc/nginx-unikraft-qemu:test | sudo docker load
 ```
 
 The image will get loaded in the local docker registry. If we want to build with
@@ -68,8 +69,10 @@ The image will get loaded in the local docker registry. If we want to build with
 command should change to the following:
 
 ```
-./bunny --LLB -f Containerfile | sudo buildctl build ... --local context=${PWD} --output "type=image,name=harbor.nbfc.io/nubificus/urunc/nginx-unikraft-qemu:test,oci-mediatypes=true,push=true"
+./bunny --LLB -f bunnyfile | sudo buildctl build ... --local context=${PWD} --output "type=image,name=harbor.nbfc.io/nubificus/urunc/nginx-unikraft-qemu:test,oci-mediatypes=true,push=true"
 ```
 
 The image will get pushed in the registry.
 
+> **NOTE**: In the above commands by simply replacing bunnyfile with
+> Containerfile and simply switch from one to the other file formats.

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,3 +9,5 @@ also serve as a boilerplate for the transition from
 The list of existing examples;
 - [Packaging a Nginx Unikraft
   unikernel](https://github.com/nubificus/bunny/tree/main/examples/Nginx_Unikraft.md).
+- [Packaging a C HTTP Web Server as a Unikraft
+  unikernel](https://github.com/nubificus/bunny/tree/main/examples/CHTTP_Unikraft.md).


### PR DESCRIPTION
Introduce support for creating an initrd for Unikraft, when the user specifies the from value of rootfs as `scratch` or leaves it empty. In that case, if the user specifies files in the include field, bunny will copy these files inside a new container and it will create an initrd inside this container.