### PR TITLE
Introduce support for raw rootfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ platforms:                                      # [3] The target unikernel platf
 rootfs:                                         # [4] (Optional) Specifies the rootfs of the unikernel.
   from: local                                   # [4a] (Optional) The source of the initrd.
   path: initrd                                  # [4b] (Required if from is not scratch) The path in the source, where a prebuilt rootfs file resides.
-  include:                                      # [4c] (Optional) A list of files to include in the rootfs
+  type: initrd                                  # [4c] The type of rootfs, in case the unikernel framework supports more than one (e.g. initrd, raw, block)
+  include:                                      # [4d] (Optional) A list of files to include in the rootfs
     - src:dst
 
 kernel:                                         # [5] Specify a prebuilt kernel to use
@@ -148,7 +149,16 @@ The fields of `bunnyfile` in more details:
         required, if `from` has a value other than `scratch`..In the
         case where the `from` field has the value `local`, then the `path` should
         be relative to the build context.
-    4c. A list of files to include in the rootfs. This field takes effect only
+    4c. The type of rootfs. In most cases the unikernel framework supports only
+        one type of a rootfs (e.g. initramfs). However, there are frameworks where
+        the rootfs can have various forms, such as initrd, block device and
+        shared-fs. For the time being, bunny can construct only two types of
+        rootfs; initrd and raw. In the case of raw all the files are simply copied
+        inside the container rootfs and we can use shared-fs or transform the
+        container rootfs to a block (this can easily happen using devmapper as a
+        snapshotter). This field is optional and `bunny` will create the default type
+        of rootfs for the respective unikernel framework.
+    4d. A list of files to include in the rootfs. This field takes effect only
         when the `from` field has the value `scratch`. The files can be defined
         in the following format: `- <path_in_the_build_context>:<path_inside_rootfs>`. The `<path_inside_rootfs>` can be omitted and then the same path as the one in `<path_in_the_build_context>` will be used.
 5. Information regarding an existing prebuilt kernel to use. For the time

--- a/examples/Nginx_Unikraft.md
+++ b/examples/Nginx_Unikraft.md
@@ -1,4 +1,4 @@
-# Packaging a unikraft unikernel with `bunny`
+# Packaging a Unikraft unikernel with `bunny`
 
 For this example, we will use an existing [Unikraft](unikraft.org) Unikernel
 image from [Unikraft's catalog](https://github.com/unikraft/catalog), we can

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,3 +11,5 @@ The list of existing examples;
   unikernel](https://github.com/nubificus/bunny/tree/main/examples/Nginx_Unikraft.md).
 - [Packaging a C HTTP Web Server as a Unikraft
   unikernel](https://github.com/nubificus/bunny/tree/main/examples/CHTTP_Unikraft.md).
+- [Packaging a Redis Rumprun
+  unikernel](https://github.com/nubificus/bunny/tree/main/examples/Redis_Rumprun.md).

--- a/examples/Redis_Rumprun.md
+++ b/examples/Redis_Rumprun.md
@@ -1,0 +1,98 @@
+# Packaging a Rumprun unikernel with `bunny`
+
+For this example, we assume we have already built a Redis
+[Rumprun](https://github.com/cloudkernels/rumprun) unikernel from
+[Rumprun-packages](https://github.com/cloudkernels/rumprun-packages) targetting
+[Solo5-hvt](https://github.com/Solo5/solo5).
+We can package it as an OCI image that [urunc](https://github.com/nubificus/urunc) can execute with `bunny`.
+
+The respective `Containerfile` that we would use with
+[pun](https://github.com/nubificus/pun) and
+[bima](https://github.com/nubificus/bima) would be:
+
+```
+#syntax=harbor.nbfc.io/nubificus/pun:latest
+FROM scratch
+
+COPY redis.hvt /unikernel/redis.hvt
+COPY redis.conf /conf/redis.conf
+
+LABEL com.urunc.unikernel.binary=/unikernel/redis.hvt
+LABEL "com.urunc.unikernel.cmdline"="redis-server /data/conf/redis.conf"
+LABEL "com.urunc.unikernel.unikernelType"="rumprun"
+LABEL "com.urunc.unikernel.hypervisor"="hvt"
+```
+
+In order to use `bunny`, instead, we need to specify the
+following `bunnyfile` to package it as an OCI image for
+[urunc](https://github.com/nubificus/urunc).
+
+```
+#syntax=harbor.nbfc.io/nubificus/bunny:latest
+version: v0.1
+
+platforms:
+  framework: rumprun
+  monitor: hvt
+  architecture: x86
+
+rootfs:
+  from: scratch
+  type: raw
+  include:
+  - redis.conf:/data/conf/redis.conf
+
+kernel:
+  from: local
+  path: redis.hvt
+
+cmdline: "redis-server /data/conf/redis.conf"
+```
+
+> **NOTE**: Since we use the raw type for rootfs, all the files in the include list
+> will simply get copied inside the container's rootfs image. Therefore, to
+> let the Rumprun unikernel access the files, we need to specify the `devmapper` as
+> a snapshotter when we deploy the unikernel. In that way, the container's rootfs
+> will be passed as a block device in the unikernel.
+
+## Building the image with bunny as buildkit's frontend
+
+In the case, we want to build the image directly through docker, using `bunny`
+as a frontend for buildkit, we can simply run the following command:
+
+```
+docker build -f bunnyfile -t harbor.nbfc.io/nubificus/urunc/redis-rumprun-hvt:test .
+```
+
+The image will get loaded in the local docker registry. If we want to build with
+[annotations](#https://github.com/nubificus/bunny/docs/annotations.md), then the
+command should change to the following:
+
+```
+docker buildx build --builder=<container-build-driver>  --output "type=image,oci-mediatypes=true" -f Containerfile -t harbor.nbfc.io/nubificus/urunc/redis-rumprun-hvt:test --push=true .
+```
+
+The image will get directly pushed in the registry.
+
+## Building the image with `bunny` and buildctl
+
+In the case we want to use `bunny` and produce a LLB to pass it to buildctl,
+We can build the image with the following command:
+
+```
+./bunny --LLB -f bunnyfile | sudo buildctl build ... --local context=${PWD} --output type=docker,name=harbor.nbfc.io/nubificus/urunc/redis-rumprun-hvt:test | docker load
+--output "type=image,name=<image-name>,oci-mediatypes=true,push=true"
+```
+
+The image will get loaded in the local docker registry. If we want to build with
+[annotations](#https://github.com/nubificus/bunny/docs/annotations.md), then the
+command should change to the following:
+
+```
+./bunny --LLB -f Containerfile | sudo buildctl build ... --local context=${PWD} --output "type=image,name=harbor.nbfc.io/nubificus/urunc/redis-rumprun-hvt:test,oci-mediatypes=true,push=true"
+```
+
+The image will get pushed in the registry.
+
+> **NOTE**: In the above commands by simply replacing bunnyfile with
+> Containerfile and simply switch from one to the other file formats.

--- a/hops/package.go
+++ b/hops/package.go
@@ -34,7 +34,7 @@ const (
 	DefaultBsdcpioImage  string = "harbor.nbfc.io/nubificus/bunny/libarchive:latest"
 	DefaultInitrdContent string = "/initrd/"
 	DefaultKernelPath    string = "/.boot/kernel"
-	DefaultInitrdPath    string = "/.boot/initrd"
+	DefaultRootfsPath    string = "/.boot/rootfs"
 	unikraftKernelPath   string = "/unikraft/bin/kernel"
 	unikraftHub          string = "unikraft.org"
 	uruncJSONPath        string = "/urunc.json"
@@ -51,6 +51,7 @@ type HopsPlatform struct {
 type HopsRootfs struct {
 	From     string   `yaml:"from"`
 	Path     string   `yaml:"path"`
+	Type     string   `yaml:"type"`
 	Includes []string `yaml:"include"`
 }
 
@@ -74,7 +75,7 @@ type PackCopies struct {    // A struct to represent a copy operation in the fin
 }
 
 type PackInstructions struct {
-	Base   string            // The Base image to use
+	Base   llb.State         // The Base image to use
 	Copies []PackCopies      // A list of packCopies, rpresenting the files to copy inside the final image
 	Annots map[string]string // Annotations
 }
@@ -84,11 +85,12 @@ func HopsToPack(hops Hops, buildContext string) (*PackInstructions, error) {
 	var instr *PackInstructions
 	instr = new(PackInstructions)
 	instr.Annots = make(map[string]string)
+	instr.Annots["com.urunc.unikernel.useDMBlock"] = "false"
 
 	if hops.Kernel.From == "local" {
 		var aCopy PackCopies
 
-		instr.Base = "scratch"
+		instr.Base = llb.Scratch()
 		instr.Annots["com.urunc.unikernel.binary"] = DefaultKernelPath
 
 		aCopy.SrcState = llb.Local(buildContext)
@@ -96,7 +98,7 @@ func HopsToPack(hops Hops, buildContext string) (*PackInstructions, error) {
 		aCopy.DstPath = DefaultKernelPath
 		instr.Copies = append(instr.Copies, aCopy)
 	} else {
-		instr.Base = hops.Kernel.From
+		instr.Base = getBase(hops.Kernel.From)
 		instr.Annots["com.urunc.unikernel.binary"] = hops.Kernel.Path
 	}
 
@@ -112,7 +114,7 @@ func HopsToPack(hops Hops, buildContext string) (*PackInstructions, error) {
 		} else if hops.Rootfs.From == "scratch" {
 			if len(hops.Rootfs.Includes) > 0 {
 				aCopy.SrcState = initrdLLB(hops.Rootfs, buildContext)
-				aCopy.SrcPath = DefaultInitrdPath
+				aCopy.SrcPath = DefaultRootfsPath
 			}
 		} else {
 			aCopy.SrcState = llb.Image(hops.Rootfs.From)
@@ -121,9 +123,68 @@ func HopsToPack(hops Hops, buildContext string) (*PackInstructions, error) {
 
 		// Add the Copy onli if we got in one of the above if claueses.
 		if aCopy.SrcPath != "" {
-			aCopy.DstPath = DefaultInitrdPath
+			aCopy.DstPath = DefaultRootfsPath
 			instr.Copies = append(instr.Copies, aCopy)
-			instr.Annots["com.urunc.unikernel.initrd"] = DefaultInitrdPath
+			instr.Annots["com.urunc.unikernel.initrd"] = DefaultRootfsPath
+		}
+	} else {
+		var aCopy PackCopies
+		// Make sure SrcPath is set to empty string, so we can check if
+		// we got inside the if clauses and really set the SrcState and SrcPath
+		aCopy.SrcPath = ""
+
+		if hops.Rootfs.From == "local" {
+			aCopy.SrcState = llb.Local(buildContext)
+			aCopy.SrcPath = hops.Rootfs.Path
+		} else if (hops.Rootfs.From == "scratch" || hops.Rootfs.From == "") {
+			if len(hops.Rootfs.Includes) > 0 {
+				if hops.Rootfs.Type == "initrd" {
+					aCopy.SrcState = initrdLLB(hops.Rootfs, buildContext)
+					aCopy.SrcPath = DefaultRootfsPath
+				} else if hops.Rootfs.Type == "raw" {
+					instr.Annots["com.urunc.unikernel.useDMBlock"] = "true"
+					if hops.Kernel.From != "local" {
+						var kernelCopy PackCopies
+						kernelCopy.SrcState = instr.Base
+						kernelCopy.SrcPath = hops.Kernel.Path
+						kernelCopy.DstPath = DefaultKernelPath
+						instr.Copies = append(instr.Copies, kernelCopy)
+						instr.Annots["com.urunc.unikernel.binary"] = DefaultKernelPath
+					}
+					local := llb.Local(buildContext)
+					instr.Base = FilesLLB(hops.Rootfs.Includes, local, instr.Base)
+				}
+			}
+		} else {
+			if hops.Rootfs.Path != "" {
+				aCopy.SrcState = llb.Image(hops.Rootfs.From)
+				aCopy.SrcPath = hops.Rootfs.Path
+			} else {
+				if hops.Rootfs.Type == "raw" {
+					instr.Annots["com.urunc.unikernel.useDMBlock"] = "true"
+				}
+				if hops.Kernel.From != "local" {
+					var kernelCopy PackCopies
+					kernelCopy.SrcState = instr.Base
+					kernelCopy.SrcPath = hops.Kernel.Path
+					kernelCopy.DstPath = DefaultKernelPath
+					instr.Copies = append(instr.Copies, kernelCopy)
+					instr.Annots["com.urunc.unikernel.binary"] = DefaultKernelPath
+				}
+				instr.Base = getBase(hops.Rootfs.From)
+			}
+		}
+
+		// Add the Copy only if we got in one of the above if claueses.
+		if aCopy.SrcPath != "" {
+			aCopy.DstPath = DefaultRootfsPath
+			instr.Copies = append(instr.Copies, aCopy)
+			if hops.Rootfs.Type == "initrd" {
+				instr.Annots["com.urunc.unikernel.initrd"] = DefaultRootfsPath
+			} else if hops.Rootfs.Type == "block" {
+				instr.Annots["com.urunc.unikernel.block"] = DefaultRootfsPath
+				instr.Annots["com.urunc.unikernel.blkMntPoint"] = "/"
+			}
 		}
 	}
 	instr.Annots["com.urunc.unikernel.unikernelType"] = hops.Platform.Framework
@@ -179,11 +240,14 @@ func ValidatePlatform(plat HopsPlatform) error {
 // 3) if from is not scratch or empty, include should not be set
 // 4) An entry in include can not have the first part (before ":" empty
 func ValidateRootfs(rootfs HopsRootfs) error {
-	if rootfs.From == "" && rootfs.Path != ""  {
-		return fmt.Errorf("The from field of rootfs is necessary, if path is set")
+	if (rootfs.From == "scratch" || rootfs.From == "") && rootfs.Path != "" {
+		return fmt.Errorf("The from field of rootfs can not be empty or scratch, if path is set")
 	}
-	if rootfs.From != "scratch" && rootfs.Path == ""  {
-		return fmt.Errorf("The path field of rootfs is necessary, if from is not scratch")
+	if rootfs.Path != "" && rootfs.Type == "raw" {
+		return fmt.Errorf("The path field in rootfs can not be combined with a raw rootfs")
+	}
+	if rootfs.From == "local" && rootfs.Type == "raw"  {
+		return fmt.Errorf("If type of rootfs is raw, then from can not be local")
 	}
 	if len(rootfs.Includes) > 0 && rootfs.From != "scratch" {
 		return fmt.Errorf("Adding files to an existing rootfs is not yet supported")
@@ -243,6 +307,10 @@ func ParseBunnyFile(fileBytes []byte, buildContext string) (*PackInstructions, e
 	if bunnyHops.Rootfs.From == "" && len(bunnyHops.Rootfs.Includes) > 0 {
 		bunnyHops.Rootfs.From = "scratch"
 	}
+	if (bunnyHops.Rootfs.From == "scratch" || bunnyHops.Rootfs.From == "") && bunnyHops.Rootfs.Type == "" {
+
+		bunnyHops.Rootfs.Type = "raw"
+	}
 	err = ValidateRootfs(bunnyHops.Rootfs)
 	if err != nil {
 		return nil, err
@@ -257,6 +325,8 @@ func ParseDockerFile(fileBytes []byte, buildContext string) (*PackInstructions, 
 	var instr *PackInstructions
 	instr = new(PackInstructions)
 	instr.Annots = make(map[string]string)
+	instr.Base = llb.Scratch()
+	setStage := false
 
 	r := bytes.NewReader(fileBytes)
 
@@ -275,10 +345,11 @@ func ParseDockerFile(fileBytes []byte, buildContext string) (*PackInstructions, 
 		switch c := cmd.(type) {
 		case *instructions.Stage:
 			// Handle FROM
-			if instr.Base != "" {
+			if setStage {
 				return nil, fmt.Errorf("Multi-stage builds are not supported")
 			}
-			instr.Base = c.BaseName
+			setStage = true
+			instr.Base = getBase(c.BaseName)
 		case *instructions.CopyCommand:
 			// Handle COPY
 			var aCopy PackCopies
@@ -331,6 +402,26 @@ func ParseFile(fileBytes []byte, buildContext string) (*PackInstructions, error)
 	return ParseBunnyFile(fileBytes, buildContext)
 }
 
+// Create a LLB State that simply copies all the files in the include list inside
+// an empty image
+func FilesLLB(fileList []string, fromState llb.State, toState llb.State) llb.State {
+	for _, file := range fileList {
+		var aCopy PackCopies
+
+		parts := strings.Split(file, ":")
+		aCopy.SrcState = fromState
+		aCopy.SrcPath = parts[0]
+		// If user did not define destination path, use the same as the source
+		aCopy.DstPath = parts[0]
+		if len(parts) != 1 && len(parts[1]) > 0 {
+			aCopy.DstPath = parts[1]
+		}
+		toState = copyIn(toState, aCopy)
+	}
+
+	return toState
+}
+
 // Create a LLB State that creates an initrd based on the data from the HopsRootfs
 // argument
 func initrdLLB(initrdContent HopsRootfs, buildContext string) llb.State {
@@ -355,7 +446,7 @@ func initrdLLB(initrdContent HopsRootfs, buildContext string) llb.State {
 	}
 
 	base = base.Dir(DefaultInitrdContent).
-		Run(llb.Shlexf("sh -c \"find . -depth -print | tac | bsdcpio -o --format newc > %s\"", DefaultInitrdPath)).Run(llb.Shlex("find /.boot/")).Root()
+		Run(llb.Shlexf("sh -c \"find . -depth -print | tac | bsdcpio -o --format newc > %s\"", DefaultRootfsPath)).Run(llb.Shlex("find /.boot/")).Root()
 
 	return base
 }
@@ -368,10 +459,31 @@ func copyIn(to llb.State, from PackCopies) llb.State {
 	return copyState
 }
 
+// Set the base image where we will pack the unikernel
+func getBase(inputBase string) llb.State {
+	var retBase llb.State
+
+	if inputBase == "scratch" {
+		retBase = llb.Scratch()
+	} else if strings.HasPrefix(inputBase, unikraftHub) {
+		// Define the platform to qemu/amd64 so we cna pull unikraft images
+		platform := ocispecs.Platform{
+			OS:           "qemu",
+			Architecture: "amd64",
+		}
+		retBase = llb.Image(inputBase, llb.Platform(platform),)
+	} else {
+		retBase = llb.Image(inputBase)
+	}
+
+	return retBase
+}
+
 // PackLLB gets a PackInstructions struct and transforms it to an LLB definition
 func PackLLB(instr PackInstructions) (*llb.Definition, error) {
 	var base llb.State
 	uruncJSON := make(map[string]string)
+	base = instr.Base
 
 	// Create urunc.json file, since annotations do not reach urunc
 	for annot, val := range instr.Annots {
@@ -381,20 +493,6 @@ func PackLLB(instr PackInstructions) (*llb.Definition, error) {
 	uruncJSONBytes, err := json.Marshal(uruncJSON)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to marshal urunc json: %v", err)
-	}
-
-	// Set the base image where we will pack the unikernel
-	if instr.Base == "scratch" {
-		base = llb.Scratch()
-	} else if strings.HasPrefix(instr.Base, unikraftHub) {
-		// Define the platform to qemu/amd64 so we cna pull unikraft images
-		platform := ocispecs.Platform{
-			OS:           "qemu",
-			Architecture: "amd64",
-		}
-		base = llb.Image(instr.Base, llb.Platform(platform),)
-	} else {
-		base = llb.Image(instr.Base)
 	}
 
 	// Perform any copies inside the image


### PR DESCRIPTION
Allow the creation of other types of rootfs, except of initrd. In particular, we can support the `raw` type, where all the files specified in include will be simply copied inside the container;s rootfs. The unikernel can then access the files either through shared-fs or by passing the container's rootfs as a block device with the use of devmapper snapshotter.