### PR TITLE
Add .golangci.yml config and fix linting errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,32 @@
+name: Code linting
+
+on:
+    pull_request:
+      branches: ["main"]
+    push:
+      branches: ["main"]
+    workflow_dispatch: # build on demand
+
+permissions:
+  contents: read
+  # allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.63
+
+          # show only new issues if it's a pull request. The default value is `false`.
+          only-new-issues: true
+          args: --timeout=5m --out-format=colored-line-number

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,19 @@
+linters:
+  enable:
+  - errcheck
+  - gofmt
+  - goimports
+  - gosec
+  - gocritic
+  - misspell
+  - revive
+  - unused
+  - dupl
+  - errname
+
+issues:
+  uniq-by-line: false
+
+run:
+  issues-exit-code: 1
+  timeout: 5m


### PR DESCRIPTION
- Introduced a .golangci.yml configuration file to enforce linting rules.
- Fixed various linting errors to improve code quality and maintainability.
- Ensured compatibility with the configured linting rules.
- Add Github action to perform linting checks.

This PR enhances code consistency and helps catch potential issues early. Let me know if any adjustments are needed!