### PR TITLE
Add support for aarch64

### DIFF
--- a/.github/workflows/build-trigger.yml
+++ b/.github/workflows/build-trigger.yml
@@ -59,5 +59,5 @@ jobs:
     secrets: inherit
     with:
       runner: '["gcc", "dind", "2204"]'
-      runner-archs: '["amd64"]'
+      runner-archs: '["amd64", "arm64"]'
       version-tag: ${{ needs.get-changed-files.outputs.version == 'true' }}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 
 	"bunny/hops"
 
@@ -111,7 +112,7 @@ func annotateRes(annots map[string]string, res *client.Result) (*client.Result, 
 
 	config := ocispecs.Image{
 		Platform: ocispecs.Platform{
-			Architecture: "amd64",
+			Architecture: runtime.GOARCH,
 			OS:           "linux",
 		},
 		RootFS: ocispecs.RootFS{


### PR DESCRIPTION
Enable the pulling and building of container images targeting  `arm64` and `arm` architectures. Moreover, let the github workflow build images for `arm64` and `armv7l`  architectures. 