### PR TITLE
Chnage the way we treat bunny version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ GO_FLAGS       := GOOS=linux
 GO_FLAGS       += CGO_ENABLED=0
 
 # Linking variables
-LDFLAGS_COMMON := -X main.version=$(VERSION)
+LDFLAGS_COMMON := -X bunny/hops.Version=$(VERSION)
 LDFLAGS_STATIC := --extldflags -static
 LDFLAGS_OPT    := -s -w
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The fields of `bunnyfile` in more details:
 |    | Description | Required | Value type | Default value |
 | -  | ----------- | -------- | ------------- | ------------ |
 | 1  | instruct Buildkit to use `bunny` for parsing this file | yes | buildkit directive | - | 
-| 2  | API version of `bunnyfile` format. The version should always be higher than `bunny`'s executable major version | yes | string in major version format (vX) | - | 
+| 2  | API version of `bunnyfile` format. Current version is v0.1 | yes | string in major version format (vX) | - |
 | 3  | Information about targeting platform | yes | - | - |
 | 3a | The unikernel/libOS to target | yes | string | - |
 | 3b | The unikernel/libOS version | no | string | latest |

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -47,8 +47,6 @@ type CLIOpts struct {
 	PrintLLB bool
 }
 
-var version string
-
 func usage() {
 
 	fmt.Println("Usage of bunny")
@@ -190,7 +188,7 @@ func main() {
 	cliOpts = parseCLIOpts()
 
 	if cliOpts.Version {
-		fmt.Printf("bunny version %s\n", version)
+		fmt.Printf("bunny version %s\n", hops.Version)
 		return
 	}
 

--- a/hops/package.go
+++ b/hops/package.go
@@ -39,7 +39,6 @@ const (
 	unikraftKernelPath   string = "/unikraft/bin/kernel"
 	unikraftHub          string = "unikraft.org"
 	uruncJSONPath        string = "/urunc.json"
-	bunnyFileVersion     string = "0.1"
 )
 
 type Platform struct {
@@ -80,6 +79,8 @@ type PackInstructions struct {
 	Copies []PackCopies      // A list of packCopies, rpresenting the files to copy inside the final image
 	Annots map[string]string // Annotations
 }
+
+var Version string
 
 // ToPack converts Hops into PackInstructions
 func (h Hops) ToPack(buildContext string) (*PackInstructions, error) {
@@ -209,20 +210,22 @@ func (h Hops) ToPack(buildContext string) (*PackInstructions, error) {
 
 // CheckBunnyfileVersion checks if the version of the user's input file
 // is compatible with the supported version.
-func CheckBunnyfileVersion(userVersion string) error {
-	if userVersion == "" {
+func CheckBunnyfileVersion(fileVersion string) error {
+	if fileVersion == "" {
 		return fmt.Errorf("The version field is necessary")
 	}
-	hopsVersion, err := version.NewVersion(bunnyFileVersion)
+	// TODO: Replace tempVersion with Version, when we reach v0.1
+	tempVersion := "0.1"
+	hopsVersion, err := version.NewVersion(tempVersion)
 	if err != nil {
-		return fmt.Errorf("Internal error in current bunnyfile version %s: %v", bunnyFileVersion, err)
+		return fmt.Errorf("Internal error in current bunnyfile version %s: %v", tempVersion, err)
 	}
-	userFileVer, err := version.NewVersion(userVersion)
+	userFileVer, err := version.NewVersion(fileVersion)
 	if err != nil {
-		return fmt.Errorf("Could not parse version in user bunnyfile %s: %v", userVersion, err)
+		return fmt.Errorf("Could not parse version in user bunnyfile %s: %v", fileVersion, err)
 	}
 	if hopsVersion.LessThan(userFileVer) {
-		return fmt.Errorf("Unsupported version %s. Please use %s or earlier", userVersion, bunnyFileVersion)
+		return fmt.Errorf("Unsupported version %s. Please use %s or earlier", fileVersion, tempVersion)
 	}
 
 	return nil


### PR DESCRIPTION
Pass the version directly to the hops package to allow easier check of bunny's binary version with the bunnyfile version. 