### PR TITLE
Refactor the way we transform hops to pac instructions

### DIFF
--- a/.github/workflows/build-trigger.yml
+++ b/.github/workflows/build-trigger.yml
@@ -1,4 +1,4 @@
-name: 🍜 Build/publish go runners
+name: 🍜 Build/publish bunny
 
 on:
   pull_request:
@@ -58,6 +58,6 @@ jobs:
     uses: ./.github/workflows/build.yml
     secrets: inherit
     with:
-      runner: '["gcc", "dind", "2204"]'
+      runner: '["base", "dind", "2204"]'
       runner-archs: '["amd64", "arm64"]'
       version-tag: ${{ needs.get-changed-files.outputs.version == 'true' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       runner:
         type: string
-        default: '["go", "2204"]'
+        default: '["base", "dind", "2204"]'
       runner-archs:
         type: string
         default: '["amd64", "aarch64"]'
@@ -113,7 +113,7 @@ jobs:
 
   manifest:
     needs: [build-all]
-    runs-on: gcc-dind-2204-amd64 # use the GitHub-hosted runner to build the image
+    runs-on: base-dind-2204-amd64
     permissions:
       contents: write # for uploading the SBOM to the release
       packages: write # for uploading the finished container

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, Nubificus LTD
+# Copyright (c) 2023-2025, Nubificus LTD
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ CNTR_OPTS ?= run --rm -it
 # Linking variables
 LINT_CNTR_OPTS ?= $(CNTR_OPTS) -v $(CURDIR):/app -w /app
 #? LINT_CNTR_IMG The linter image to use (default: golangci/golangci-lint:v1.53.3)
-LINT_CNTR_IMG  ?= golangci/golangci-lint:v1.53.3
+LINT_CNTR_IMG  ?= golangci/golangci-lint:v1.64
 LINT_CNTR_CMD  ?= golangci-lint run -v --timeout=5m
 
 # Source files variables

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ platforms:                                      # [3] The target platform for bu
   architecture: x86                             # [3d] The target architecture.
 
 rootfs:                                         # [4] (Optional) Specifies the rootfs of the unikernel.
-  from: local                                   # [4a] (Optional) The source of the rootfs.
+  from: local                                   # [4a] (Optional) The source or base of the rootfs.
   path: initrd                                  # [4b] (Required if from is not scratch) The path in the source, where the prebuilt rootfs file resides.
   type: initrd                                  # [4c] (optional) The type of rootfs (e.g. initrd, raw, block)
   include:                                      # [4d] (Optional) A list of local files to include in the rootfs

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024, Nubificus LTD
+// Copyright (c) 2023-2025, Nubificus LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/hops/frameworks.go
+++ b/hops/frameworks.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2023-2025, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hops
+
+import (
+	"github.com/moby/buildkit/client/llb"
+)
+
+type Framework interface {
+	Name() string
+	GetRootfsType() string
+	SupportsRootfsType(string) bool
+	SupportsFsType(string) bool
+	SupportsMonitor(string) bool
+	SupportsArch(string) bool
+	CreateRootfs(string) llb.State
+	BuildKernel(string) llb.State
+}

--- a/hops/generic.go
+++ b/hops/generic.go
@@ -84,7 +84,7 @@ func (i *GenericInfo) CreateRootfs(buildContext string) llb.State {
 	switch i.Rootfs.Type {
 	case "initrd":
 		contentState := FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
-		return initrdLLB(contentState)
+		return InitrdLLB(contentState)
 	case "raw":
 		return FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
 	default:

--- a/hops/generic.go
+++ b/hops/generic.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2023-2025, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hops
+
+import (
+	"github.com/moby/buildkit/client/llb"
+)
+
+const (
+	genericName = "generic"
+)
+
+type GenericInfo struct {
+	Version string
+	Monitor string
+	Arch    string
+	Rootfs  Rootfs
+}
+
+func newGeneric(plat Platform, rfs Rootfs) *GenericInfo {
+	if rfs.Type == "" {
+		rfs.Type = "raw"
+	}
+	return &GenericInfo{
+		Version: plat.Version,
+		Monitor: plat.Monitor,
+		Arch:    plat.Arch,
+		Rootfs:  rfs,
+	}
+}
+
+func (i *GenericInfo) Name() string {
+	return genericName
+}
+
+func (i *GenericInfo) GetRootfsType() string {
+	return i.Rootfs.Type
+}
+
+func (i *GenericInfo) SupportsRootfsType(rootfsType string) bool {
+	switch rootfsType {
+	case "initrd":
+		return true
+	case "raw":
+		return true
+	default:
+		return false
+	}
+}
+
+func (i *GenericInfo) SupportsFsType(string) bool {
+	return false
+}
+
+func (i *GenericInfo) SupportsMonitor(string) bool {
+	return false
+}
+
+func (i *GenericInfo) SupportsArch(arch string) bool {
+	switch arch {
+	case "x86_64", "amd64":
+		return true
+	case "aarch64":
+		return true
+	default:
+		return false
+	}
+}
+
+func (i *GenericInfo) CreateRootfs(buildContext string) llb.State {
+	local := llb.Local(buildContext)
+	switch i.Rootfs.Type {
+	case "initrd":
+		contentState := FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
+		return initrdLLB(contentState)
+	case "raw":
+		return FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
+	default:
+		// We should never reach this point
+		return llb.Scratch()
+	}
+}
+
+func (i *GenericInfo) BuildKernel(_ string) llb.State {
+	return llb.Scratch()
+}

--- a/hops/package.go
+++ b/hops/package.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024, Nubificus LTD
+// Copyright (c) 2023-2025, Nubificus LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/hops/package.go
+++ b/hops/package.go
@@ -248,12 +248,12 @@ func ValidatePlatform(plat Platform) error {
 
 // ValidateRootfs checks if user input meets all conditions regarding the rootfs
 // field. The conditions are:
-// 1) if from is empty then path should also be empty
+// 1) if from is empty/scratch then path should also be empty
 // 2) if path is empty then from should also be empty
 // 3) if from is not scratch or empty, include should not be set
 // 4) An entry in include can not have the first part (before ":" empty
 func ValidateRootfs(rootfs Rootfs) error {
-	if (rootfs.From == "scratch" || rootfs.From == "") && rootfs.Path != "" {
+	if (rootfs.From == "scratch") && rootfs.Path != "" {
 		return fmt.Errorf("The from field of rootfs can not be empty or scratch, if path is set")
 	}
 	if rootfs.Path != "" && rootfs.Type == "raw" {
@@ -316,11 +316,13 @@ func ParseBunnyFile(fileBytes []byte, buildContext string) (*PackInstructions, e
 		return nil, err
 	}
 
-	// Set default value of from to scratch if include is specified.
-	if bunnyHops.Rootfs.From == "" && len(bunnyHops.Rootfs.Includes) > 0 {
+	// Set default value of from to scratch
+	// Make sure that any reference to Rootfs.From can not be an empty string
+	if bunnyHops.Rootfs.From == "" {
 		bunnyHops.Rootfs.From = "scratch"
 	}
-	if (bunnyHops.Rootfs.From == "scratch" || bunnyHops.Rootfs.From == "") && bunnyHops.Rootfs.Type == "" {
+	// TODO: Change it to unikernel supported rootfs type
+	if (bunnyHops.Rootfs.From == "scratch") && bunnyHops.Rootfs.Type == "" {
 
 		bunnyHops.Rootfs.Type = "raw"
 	}

--- a/hops/unikraft.go
+++ b/hops/unikraft.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2023-2025, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hops
+
+import (
+	"github.com/moby/buildkit/client/llb"
+)
+
+const (
+	unikraftName = "unikraft"
+)
+
+type UnikraftInfo struct {
+	Version string
+	Monitor string
+	Arch    string
+	Rootfs  Rootfs
+}
+
+func newUnikraft(plat Platform, rfs Rootfs) *UnikraftInfo {
+	if rfs.Type == "" {
+		rfs.Type = "initrd"
+	}
+	return &UnikraftInfo{
+		Version: plat.Version,
+		Monitor: plat.Monitor,
+		Arch:    plat.Arch,
+		Rootfs:  rfs,
+	}
+}
+
+func (i *UnikraftInfo) Name() string {
+	return unikraftName
+}
+
+func (i *UnikraftInfo) GetRootfsType() string {
+	return i.Rootfs.Type
+}
+
+func (i *UnikraftInfo) SupportsRootfsType(rootfsType string) bool {
+	switch rootfsType {
+	case "initrd":
+		return true
+	default:
+		return false
+	}
+}
+
+func (i *UnikraftInfo) SupportsFsType(string) bool {
+	return false
+}
+
+func (i *UnikraftInfo) SupportsMonitor(string) bool {
+	return false
+}
+
+func (i *UnikraftInfo) SupportsArch(arch string) bool {
+	switch arch {
+	case "x86_64", "amd64":
+		return true
+	case "aarch64":
+		return true
+	default:
+		return false
+	}
+}
+
+func (i *UnikraftInfo) CreateRootfs(buildContext string) llb.State {
+	// TODO: Add support for any other possible supported rootfs types
+	// Currently, by default, we will build a initrd type.
+	local := llb.Local(buildContext)
+	contentState := FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
+	return initrdLLB(contentState)
+}
+
+func (i *UnikraftInfo) BuildKernel(_ string) llb.State {
+	return llb.Scratch()
+}

--- a/hops/unikraft.go
+++ b/hops/unikraft.go
@@ -82,7 +82,7 @@ func (i *UnikraftInfo) CreateRootfs(buildContext string) llb.State {
 	// Currently, by default, we will build a initrd type.
 	local := llb.Local(buildContext)
 	contentState := FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
-	return initrdLLB(contentState)
+	return InitrdLLB(contentState)
 }
 
 func (i *UnikraftInfo) BuildKernel(_ string) llb.State {


### PR DESCRIPTION
The most part of work for the transformation of bunnyfile to LLB was taking place in `ToPack` function. However, to further extend the functionalities of `bunny` and add support for more frameworks and build options, we had to improve this function. Therefore, this PR simplifies this function and introduces the `Framework` interface, which implements the following functions:
- `Name`: Get the name of the framework.
- `GetRootfsType`: Get the rootfs type to build for this framework.
- `SupportsRootfsType`: Returns (true or false) if the framework supports the rootfs type passed as argument.
- `SupportsFsType`: Returns (true or false) if the framework supports the filesystem type passed as argument.
- `SupportsMonitor`: Returns (true or false) if the framework supports the monitor passed as argument. 
- `SupportsArch`: Returns (true or false) if the framework supports the architecture passed as argument.
- `CreateRootfs`: Returns a llb State with the generated rootfs for this framework.
- `BuildKernel` - Returns a llb State with the generated kernel for this framework.
  
As a result, adding support for more frameworks and building their rootfs/kernel should be much easier and straightforward.

Furthermore, use mounts instead of copies to get the cpio file from the initrdLLB. 