### PR TITLE
Improve error handling for FilesLLB and reaarange constants

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.1
 require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/moby/buildkit v0.20.1
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/stretchr/testify v1.10.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -36,7 +37,6 @@ require (
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/sys/signal v0.7.1 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -54,7 +54,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.35.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
-	golang.org/x/net v0.37.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.37.0 h1:1zLorHbz+LYj7MQlSf1+2tPIIgibq2eL5xkrGk6f+2c=
-golang.org/x/net v0.37.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/hops/frameworks.go
+++ b/hops/frameworks.go
@@ -25,6 +25,6 @@ type Framework interface {
 	SupportsFsType(string) bool
 	SupportsMonitor(string) bool
 	SupportsArch(string) bool
-	CreateRootfs(string) llb.State
+	CreateRootfs(string) (llb.State, error)
 	BuildKernel(string) llb.State
 }

--- a/hops/generic.go
+++ b/hops/generic.go
@@ -15,6 +15,8 @@
 package hops
 
 import (
+	"fmt"
+
 	"github.com/moby/buildkit/client/llb"
 )
 
@@ -79,17 +81,20 @@ func (i *GenericInfo) SupportsArch(arch string) bool {
 	}
 }
 
-func (i *GenericInfo) CreateRootfs(buildContext string) llb.State {
+func (i *GenericInfo) CreateRootfs(buildContext string) (llb.State, error) {
 	local := llb.Local(buildContext)
 	switch i.Rootfs.Type {
 	case "initrd":
-		contentState := FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
-		return InitrdLLB(contentState)
+		contentState, err := FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
+		if err != nil {
+			return llb.Scratch(), err
+		}
+		return InitrdLLB(contentState), nil
 	case "raw":
 		return FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
 	default:
 		// We should never reach this point
-		return llb.Scratch()
+		return llb.Scratch(), fmt.Errorf("Unsupported rootfs type")
 	}
 }
 

--- a/hops/llb.go
+++ b/hops/llb.go
@@ -15,6 +15,7 @@
 package hops
 
 import (
+	"fmt"
 	"runtime"
 	"strings"
 
@@ -24,8 +25,8 @@ import (
 
 // Create a LLB State that simply copies all the files in the include list inside
 // an empty image
-func FilesLLB(fileList []string, fromState llb.State, toState llb.State) llb.State {
-	var retState llb.State
+func FilesLLB(fileList []string, fromState llb.State, toState llb.State) (llb.State, error) {
+	retState := llb.Scratch()
 	for i, file := range fileList {
 		var aCopy PackCopies
 
@@ -34,8 +35,8 @@ func FilesLLB(fileList []string, fromState llb.State, toState llb.State) llb.Sta
 		aCopy.SrcPath = parts[0]
 		// If user did not define destination path, use the same as the source
 		aCopy.DstPath = parts[0]
-		if len(parts) > 2 || len(parts[0]) == 0 {
-			continue
+		if len(parts) < 1 || len(parts) > 2 || len(parts[0]) == 0 {
+			return llb.Scratch(), fmt.Errorf("Invalid format of the file list to copy")
 		}
 		if len(parts) == 2 && len(parts[1]) > 0 {
 			aCopy.DstPath = parts[1]
@@ -47,7 +48,7 @@ func FilesLLB(fileList []string, fromState llb.State, toState llb.State) llb.Sta
 		}
 	}
 
-	return retState
+	return retState, nil
 }
 
 // Create a LLB State that constructs a cpio file with the data in the content

--- a/hops/llb.go
+++ b/hops/llb.go
@@ -23,6 +23,10 @@ import (
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+const (
+	defaultBsdcpioImage string = "harbor.nbfc.io/nubificus/bunny/libarchive:latest"
+)
+
 // Create a LLB State that simply copies all the files in the include list inside
 // an empty image
 func FilesLLB(fileList []string, fromState llb.State, toState llb.State) (llb.State, error) {
@@ -56,7 +60,7 @@ func FilesLLB(fileList []string, fromState llb.State, toState llb.State) (llb.St
 func InitrdLLB(content llb.State) llb.State {
 	outDir := "/.boot"
 	workDir := "/workdir"
-	toolSet := llb.Image(DefaultBsdcpioImage, llb.WithCustomName("Internal:Create initrd")).
+	toolSet := llb.Image(defaultBsdcpioImage, llb.WithCustomName("Internal:Create initrd")).
 		File(llb.Mkdir("/tmp", 0755))
 	cpioExec := toolSet.Dir(workDir).
 		Run(llb.Shlexf("sh -c \"find . -depth -print | tac | bsdcpio -o --format newc > %s\"", DefaultRootfsPath), llb.AddMount(workDir, content, llb.Readonly))

--- a/hops/llb_test.go
+++ b/hops/llb_test.go
@@ -31,7 +31,8 @@ func TestLLBFiles(t *testing.T) {
 		dst := llb.Scratch()
 		files := []string{"foo1"}
 
-		state := FilesLLB(files, src, dst)
+		state, err := FilesLLB(files, src, dst)
+		require.NoError(t, err)
 		def, err := state.Marshal(context.TODO())
 
 		require.NoError(t, err)
@@ -63,7 +64,8 @@ func TestLLBFiles(t *testing.T) {
 		dst := llb.Image("foo")
 		files := []string{"foo1:bar1", "foo2:bar2"}
 
-		state := FilesLLB(files, src, dst)
+		state, err := FilesLLB(files, src, dst)
+		require.NoError(t, err)
 		def, err := state.Marshal(context.TODO())
 
 		require.NoError(t, err)
@@ -103,7 +105,8 @@ func TestLLBFiles(t *testing.T) {
 		dst := llb.Scratch()
 		files := []string{}
 
-		state := FilesLLB(files, src, dst)
+		state, err := FilesLLB(files, src, dst)
+		require.NoError(t, err)
 		def, err := state.Marshal(context.TODO())
 
 		require.NoError(t, err)
@@ -115,7 +118,8 @@ func TestLLBFiles(t *testing.T) {
 		dst := llb.Scratch()
 		files := []string{":foo"}
 
-		state := FilesLLB(files, src, dst)
+		state, err := FilesLLB(files, src, dst)
+		require.EqualError(t, err, "Invalid format of the file list to copy")
 		def, err := state.Marshal(context.TODO())
 
 		require.NoError(t, err)
@@ -127,7 +131,8 @@ func TestLLBFiles(t *testing.T) {
 		dst := llb.Scratch()
 		files := []string{"foo:a:b"}
 
-		state := FilesLLB(files, src, dst)
+		state, err := FilesLLB(files, src, dst)
+		require.EqualError(t, err, "Invalid format of the file list to copy")
 		def, err := state.Marshal(context.TODO())
 
 		require.NoError(t, err)

--- a/hops/llb_test.go
+++ b/hops/llb_test.go
@@ -212,7 +212,7 @@ func TestLLBInitrd(t *testing.T) {
 	})
 	t.Run("Tool state", func(t *testing.T) {
 		toolSrc := tools.Op.(*pb.Op_Source).Source
-		require.Equal(t, "docker-image://"+DefaultBsdcpioImage, toolSrc.Identifier)
+		require.Equal(t, "docker-image://"+defaultBsdcpioImage, toolSrc.Identifier)
 	})
 }
 

--- a/hops/package.go
+++ b/hops/package.go
@@ -181,7 +181,10 @@ func ToPack(h *Hops, buildContext string) (*PackInstructions, error) {
 
 	// If the user has not specified a type, then CreateRootfs will build
 	// the default rootfs type for the specified framework.
-	rootfsState := framework.CreateRootfs(buildContext)
+	rootfsState, err := framework.CreateRootfs(buildContext)
+	if err != nil {
+		return nil, err
+	}
 	switch framework.GetRootfsType() {
 	case "initrd":
 		instr.Annots["com.urunc.unikernel.initrd"] = DefaultRootfsPath

--- a/hops/package.go
+++ b/hops/package.go
@@ -25,20 +25,17 @@ import (
 )
 
 const (
-	DefaultBsdcpioImage  string = "harbor.nbfc.io/nubificus/bunny/libarchive:latest"
-	DefaultInitrdContent string = "/initrd/"
-	DefaultKernelPath    string = "/.boot/kernel"
-	DefaultRootfsPath    string = "/.boot/rootfs"
-	unikraftKernelPath   string = "/unikraft/bin/kernel"
-	unikraftHub          string = "unikraft.org"
-	uruncJSONPath        string = "/urunc.json"
+	DefaultKernelPath string = "/.boot/kernel"
+	DefaultRootfsPath string = "/.boot/rootfs"
+	unikraftHub       string = "unikraft.org"
+	uruncJSONPath     string = "/urunc.json"
 )
 
 type Platform struct {
 	Framework string `yaml:"framework"`
 	Version   string `yaml:"version"`
 	Monitor   string `yaml:"monitor"`
-	Arch      string `yaml:"arch"`
+	Arch      string `yaml:"architecture"`
 }
 
 type Rootfs struct {
@@ -61,16 +58,23 @@ type Hops struct {
 	Cmd      string   `yaml:"cmdline"`
 }
 
-type PackCopies struct { // A struct to represent a copy operation in the final image
-	SrcState llb.State // The state where the file resides
-	SrcPath  string    // The source path inside the SrcState where the file resides
-	DstPath  string    // The destination path to copy the file inside the final image
+// A struct to represent a copy operation in the final image
+type PackCopies struct {
+	// The state where the file resides
+	SrcState llb.State
+	// The source path inside the SrcState where the file resides
+	SrcPath string
+	// The destination path to copy the file inside the final image
+	DstPath string
 }
 
 type PackInstructions struct {
-	Base   llb.State         // The Base image to use
-	Copies []PackCopies      // The files to copy inside the final image
-	Annots map[string]string // Annotations
+	// The Base image to use
+	Base llb.State
+	// The files to copy inside the final image
+	Copies []PackCopies
+	// Annotations
+	Annots map[string]string
 }
 
 // ToPack converts Hops into PackInstructions

--- a/hops/unikraft.go
+++ b/hops/unikraft.go
@@ -77,12 +77,15 @@ func (i *UnikraftInfo) SupportsArch(arch string) bool {
 	}
 }
 
-func (i *UnikraftInfo) CreateRootfs(buildContext string) llb.State {
+func (i *UnikraftInfo) CreateRootfs(buildContext string) (llb.State, error) {
 	// TODO: Add support for any other possible supported rootfs types
 	// Currently, by default, we will build a initrd type.
 	local := llb.Local(buildContext)
-	contentState := FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
-	return InitrdLLB(contentState)
+	contentState, err := FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
+	if err != nil {
+		return llb.Scratch(), err
+	}
+	return InitrdLLB(contentState), nil
 }
 
 func (i *UnikraftInfo) BuildKernel(_ string) llb.State {


### PR DESCRIPTION
Improve the error handling of the function that creates a state based on a list of files that we want to copy inside there. The error handling mostly refers to the case where the format of the files is incorrect.

Also rearrange some constant values and place them in the files that they are actually used.