### PR TITLE
Remove dummy entrypoint

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -120,7 +120,6 @@ func annotateRes(annots map[string]string, res *client.Result) (*client.Result, 
 		},
 		Config: ocispecs.ImageConfig{
 			WorkingDir: "/",
-			Entrypoint: []string{"/hello2"},
 			Labels:     annots,
 		},
 	}


### PR DESCRIPTION
A quick fix of removing the dummy entrypoint in the image config. We do not need to set the entrypoint and it breaks the new functionality in urunc to set up the cli arguments during the container spawning.