### PR TITLE
Use cmdline annotation as image's cmd

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"bunny/hops"
 
@@ -120,6 +121,7 @@ func annotateRes(annots map[string]string, res *client.Result) (*client.Result, 
 		},
 		Config: ocispecs.ImageConfig{
 			WorkingDir: "/",
+			Cmd:        strings.Fields(annots["com.urunc.unikernel.cmdline"]),
 			Labels:     annots,
 		},
 	}


### PR DESCRIPTION
Set the final's image configuration cmd field the same as the cmdline annotation. We do that since docker does not allow us to execute containers with empty args.