### PR TITLE
Change useDMBlock annotation to mountRootfs

### DIFF
--- a/hops/package.go
+++ b/hops/package.go
@@ -82,7 +82,7 @@ func ToPack(h *Hops, buildContext string) (*PackInstructions, error) {
 	var framework Framework
 	instr := &PackInstructions{
 		Annots: map[string]string{
-			"com.urunc.unikernel.useDMBlock":    "false",
+			"com.urunc.unikernel.mountRootfs":   "false",
 			"com.urunc.unikernel.unikernelType": h.Platform.Framework,
 			"com.urunc.unikernel.cmdline":       h.Cmd,
 			"com.urunc.unikernel.hypervisor":    h.Platform.Monitor,
@@ -160,7 +160,7 @@ func ToPack(h *Hops, buildContext string) (*PackInstructions, error) {
 			if !framework.SupportsRootfsType("raw") {
 				return nil, fmt.Errorf("%s does not support raw rootfs type", framework.Name())
 			}
-			instr.Annots["com.urunc.unikernel.useDMBlock"] = "true"
+			instr.Annots["com.urunc.unikernel.mountRootfs"] = "true"
 			// Switch the base to the rootfs's From image
 			// and copy the kernel inside it.
 			if h.Kernel.From != "local" {
@@ -193,7 +193,7 @@ func ToPack(h *Hops, buildContext string) (*PackInstructions, error) {
 	case "initrd":
 		instr.Annots["com.urunc.unikernel.initrd"] = DefaultRootfsPath
 	case "raw":
-		instr.Annots["com.urunc.unikernel.useDMBlock"] = "true"
+		instr.Annots["com.urunc.unikernel.mountRootfs"] = "true"
 	default:
 		return nil, fmt.Errorf("Unexpected RootfsType value from framework")
 	}

--- a/hops/unikraft.go
+++ b/hops/unikraft.go
@@ -53,6 +53,8 @@ func (i *UnikraftInfo) SupportsRootfsType(rootfsType string) bool {
 	switch rootfsType {
 	case "initrd":
 		return true
+	case "raw":
+		return true
 	default:
 		return false
 	}

--- a/hops/unikraft_test.go
+++ b/hops/unikraft_test.go
@@ -101,12 +101,16 @@ func TestUnikraftGetRootfsType(t *testing.T) {
 
 func TestUnikraftSupportsRootfsType(t *testing.T) {
 	unikraft := &UnikraftInfo{}
-	t.Run("Supported rootfs type", func(t *testing.T) {
+	t.Run("Supported rootfs type initrd", func(t *testing.T) {
 		require.Equal(t, true, unikraft.SupportsRootfsType("initrd"))
 
 	})
-	t.Run("Unsupported rootfs type", func(t *testing.T) {
-		require.Equal(t, false, unikraft.SupportsRootfsType("raw"))
+	t.Run("Unsupported rootfs type raw", func(t *testing.T) {
+		require.Equal(t, true, unikraft.SupportsRootfsType("raw"))
+
+	})
+	t.Run("Unsupported rootfs type block", func(t *testing.T) {
+		require.Equal(t, false, unikraft.SupportsRootfsType("block"))
 
 	})
 }


### PR DESCRIPTION
Change the annotation that bunny uses for "raw" rootfs types from useDMBlock to mountRootfs, since urunc has changed this annotation. Furthermore, with the support of shared-fs in urunc, we can boot Unikraft unikernels with raw rootfs type. Therefore, add the supported type in Unikraft.