### PR TITLE
Add further new unit tests to cover more cases

### DIFF
--- a/hops/generic_test.go
+++ b/hops/generic_test.go
@@ -239,6 +239,41 @@ func TestGenericCreateRootfs(t *testing.T) {
 		toolDgst := tmp.Inputs[0].Digest
 		require.Equal(t, m[toolDgst], arr[0])
 	})
+	t.Run("With raw rootfs type and invalid files structure", func(t *testing.T) {
+		plat := Platform{
+			Version: "1.0",
+			Monitor: "foo",
+			Arch:    "bar",
+		}
+		rootfs := Rootfs{
+			From:     "foo",
+			Path:     "bar",
+			Type:     "initrd",
+			Includes: []string{":bar", "ka"},
+		}
+
+		generic := NewGeneric(plat, rootfs)
+		_, err := generic.CreateRootfs("context")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "Invalid format of the file")
+	})
+	t.Run("Invalid rootfs type", func(t *testing.T) {
+		plat := Platform{
+			Version: "1.0",
+			Monitor: "foo",
+			Arch:    "bar",
+		}
+		rootfs := Rootfs{
+			From:     "foo",
+			Path:     "bar",
+			Type:     "qwe",
+			Includes: []string{"foo:bar", "ka"},
+		}
+
+		generic := NewGeneric(plat, rootfs)
+		_, err := generic.CreateRootfs("context")
+		require.ErrorContains(t, err, "Unsupported rootfs type")
+	})
 }
 
 func TestGenericBuildKernel(t *testing.T) {

--- a/hops/parse_file_test.go
+++ b/hops/parse_file_test.go
@@ -304,7 +304,13 @@ LABEL bar=foo
 		require.Equal(t, "foo", i.Annots["bar"])
 		require.Len(t, i.Copies, 0)
 	})
-
+	t.Run("Invalid empty Containerfile", func(t *testing.T) {
+		input := []byte("")
+		i, err := ParseContainerfile(input, "foo")
+		require.Error(t, err)
+		require.Nil(t, i)
+		require.ErrorContains(t, err, "Failed to parse data as Dockerfile")
+	})
 }
 
 func TestParsefile(t *testing.T) {
@@ -397,6 +403,12 @@ cmdline: "foo bar"
 `),
 			expectError: true,
 			errorText:   "The framework field of platforms is necessary",
+		},
+		{
+			name:        "Invalid file single line",
+			input:       []byte(`#syntax=foo`),
+			expectError: true,
+			errorText:   "Invalid format of file",
 		},
 	}
 

--- a/hops/unikraft_test.go
+++ b/hops/unikraft_test.go
@@ -159,65 +159,84 @@ func TestUnikraftSupportsArch(t *testing.T) {
 }
 
 func TestUnikraftCreateRootfs(t *testing.T) {
-	plat := Platform{
-		Version: "1.0",
-		Monitor: "foo",
-		Arch:    "bar",
-	}
-	rootfs := Rootfs{
-		From:     "foo",
-		Path:     "bar",
-		Type:     "initrd",
-		Includes: []string{"foo:bar"},
-	}
+	t.Run("Rootfs type initrd and single file", func(t *testing.T) {
+		plat := Platform{
+			Version: "1.0",
+			Monitor: "foo",
+			Arch:    "bar",
+		}
+		rootfs := Rootfs{
+			From:     "scratch",
+			Type:     "initrd",
+			Includes: []string{"foo:bar"},
+		}
 
-	unikraft := NewUnikraft(plat, rootfs)
-	state, err := unikraft.CreateRootfs("context")
-	require.NoError(t, err)
-	def, err := state.Marshal(context.TODO())
+		unikraft := NewUnikraft(plat, rootfs)
+		state, err := unikraft.CreateRootfs("context")
+		require.NoError(t, err)
+		def, err := state.Marshal(context.TODO())
 
-	require.NoError(t, err)
-	m, arr := parseDef(t, def.Def)
-	// We expect 7 output states: 2 for copy files and 4 for initrd and 1 for final
-	// output
-	require.Equal(t, 7, len(arr))
-	// The last one (final output) should just have a single input
-	last := arr[len(arr)-1]
-	require.Equal(t, 1, len(last.Inputs))
-	// which is the exec op of initrd
-	lastInputDgst := last.Inputs[0].Digest
-	require.Equal(t, m[lastInputDgst], arr[5])
-	e := arr[5]
-	exec := e.Op.(*pb.Op_Exec).Exec
-	require.Equal(t, 3, len(exec.Meta.Args))
-	// the exec should have three inputs
-	require.Equal(t, 3, len(e.Inputs))
-	// the last of which should be the state with the initrd content
-	// that we passed as argument
-	sDgst := e.Inputs[2].Digest
-	require.Equal(t, m[sDgst], arr[4])
-	c := arr[4]
-	lDgst := c.Inputs[0].Digest
-	require.Equal(t, m[lDgst], arr[3])
-	l := arr[3].Op.(*pb.Op_Source).Source
-	require.Equal(t, "local://context", l.Identifier)
-	cf := c.Op.(*pb.Op_File).File
-	require.Equal(t, 1, len(cf.Actions))
-	cp := cf.Actions[0].Action.(*pb.FileAction_Copy).Copy
-	require.Equal(t, "/foo", cp.Src)
-	require.Equal(t, "/bar", cp.Dest)
-	// the second of which should be the state that creates the directory
-	// where the cpio file will get stored
-	oDgst := e.Inputs[1].Digest
-	require.Equal(t, m[oDgst], arr[2])
-	// the first of which should be the state that creates the tmp directory
-	tDgst := e.Inputs[0].Digest
-	require.Equal(t, m[tDgst], arr[1])
-	tmp := arr[1]
-	// The state that create the tmp directory has one input, which is the source of
-	// the tools
-	toolDgst := tmp.Inputs[0].Digest
-	require.Equal(t, m[toolDgst], arr[0])
+		require.NoError(t, err)
+		m, arr := parseDef(t, def.Def)
+		// We expect 7 output states: 2 for copy files and 4 for initrd and 1 for final
+		// output
+		require.Equal(t, 7, len(arr))
+		// The last one (final output) should just have a single input
+		last := arr[len(arr)-1]
+		require.Equal(t, 1, len(last.Inputs))
+		// which is the exec op of initrd
+		lastInputDgst := last.Inputs[0].Digest
+		require.Equal(t, m[lastInputDgst], arr[5])
+		e := arr[5]
+		exec := e.Op.(*pb.Op_Exec).Exec
+		require.Equal(t, 3, len(exec.Meta.Args))
+		// the exec should have three inputs
+		require.Equal(t, 3, len(e.Inputs))
+		// the last of which should be the state with the initrd content
+		// that we passed as argument
+		sDgst := e.Inputs[2].Digest
+		require.Equal(t, m[sDgst], arr[4])
+		c := arr[4]
+		lDgst := c.Inputs[0].Digest
+		require.Equal(t, m[lDgst], arr[3])
+		l := arr[3].Op.(*pb.Op_Source).Source
+		require.Equal(t, "local://context", l.Identifier)
+		cf := c.Op.(*pb.Op_File).File
+		require.Equal(t, 1, len(cf.Actions))
+		cp := cf.Actions[0].Action.(*pb.FileAction_Copy).Copy
+		require.Equal(t, "/foo", cp.Src)
+		require.Equal(t, "/bar", cp.Dest)
+		// the second of which should be the state that creates the directory
+		// where the cpio file will get stored
+		oDgst := e.Inputs[1].Digest
+		require.Equal(t, m[oDgst], arr[2])
+		// the first of which should be the state that creates the tmp directory
+		tDgst := e.Inputs[0].Digest
+		require.Equal(t, m[tDgst], arr[1])
+		tmp := arr[1]
+		// The state that create the tmp directory has one input, which is the source of
+		// the tools
+		toolDgst := tmp.Inputs[0].Digest
+		require.Equal(t, m[toolDgst], arr[0])
+	})
+	t.Run("Invalid files structure", func(t *testing.T) {
+		plat := Platform{
+			Version: "1.0",
+			Monitor: "foo",
+			Arch:    "bar",
+		}
+		rootfs := Rootfs{
+			From:     "foo",
+			Path:     "bar",
+			Type:     "initrd",
+			Includes: []string{":bar", "ka"},
+		}
+
+		unikraft := NewUnikraft(plat, rootfs)
+		_, err := unikraft.CreateRootfs("context")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "Invalid format of the file")
+	})
 }
 
 func TestUnikraftBuildKernel(t *testing.T) {

--- a/hops/validate_test.go
+++ b/hops/validate_test.go
@@ -167,6 +167,24 @@ func TestValidateBunnyfileRootfs(t *testing.T) {
 			errorText:   "The from field of rootfs can not be empty",
 		},
 		{
+			name:        "Invalid non-empty path, type raw",
+			input:       "local/path/raw/",
+			expectError: true,
+			errorText:   "The path field in rootfs can not be combined",
+		},
+		{
+			name:        "Invalid from local with type raw",
+			input:       "local//raw/",
+			expectError: true,
+			errorText:   "If type of rootfs is raw, then from can not",
+		},
+		{
+			name:        "Invalid from local with includes",
+			input:       "local/path//foo:bar",
+			expectError: true,
+			errorText:   "Adding files to an existing rootfs is not yet",
+		},
+		{
 			name:        "Invalid include with no source",
 			input:       "///:bar",
 			expectError: true,


### PR DESCRIPTION
Add further unit tests to cover more cases when validating and parsing files, but also on creating a rootfs for Unikraft and generic frameworks.