### PR TITLE
Switch form a single string for cmdline to array of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ kernel:                                         # [5] Specify a prebuilt kernel 
   from: local                                   # [5a] Specify the source of a prebuilt kernel.
   path: local                                   # [5b] The path where the kernel image resides.
 
-cmdline: hello                                  # [6] The cmdline of the app.
+cmd: ["hello"]                                  # [6] The command line arguments of the app.
 
 ```
 
@@ -178,7 +178,7 @@ kernel:
   from: local
   path: kernel
 
-cmdline: /server
+cmd: ["/server"]
 ```
 
 We can then package everything with the following command:
@@ -193,7 +193,7 @@ The above `bunnyfile` will perform the following steps:
 2. Copy the file `kernel` from the local build context to the OCI image we used
    in the previous step at `/boot/kernel`.
 3. Set up [`urunc`'s annotations](https://urunc.io/image-building/#annotations)
-   using all the information in the file (e.g. framework, version, cmdline,
+   using all the information in the file (e.g. framework, version, cmd,
    binary, initrd).
 4. Produce the final OCI image.
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -146,7 +146,7 @@ func bunnyBuilder(ctx context.Context, c client.Client) (*client.Result, error) 
 
 	// Set some default values in the Image config
 	// and add cmdline and Labels
-	rc.UpdateConfig(packInst.Annots)
+	rc.UpdateConfig(packInst.Annots, packInst.Config.Cmd)
 
 	// Apply annotations and the new config to the solver's result
 	err = rc.ApplyConfig(packInst.Annots)

--- a/examples/CHTTP_Unikraft.md
+++ b/examples/CHTTP_Unikraft.md
@@ -1,7 +1,7 @@
 # Creating the initrd and packaging a Unikraft unikernel with `bunny`
 
 For this example, we will use the [C HTTP Web
-Server](https://github.com/unikraft/catalog/tree/main/examples/http-c) example
+Server](https://github.com/unikraft/catalog/tree/main/examples/httpserver-gcc13.2) example
 in Unikraft's catalog. To build the unikernel, we mainly need to:
 1. Build the C HTTP server
 2. Create the initrd for Unikraft
@@ -52,10 +52,14 @@ To package everything together, we can use the following `Containerfile`:
 #syntax=harbor.nbfc.io/nubificus/bunny:latest
 FROM unikraft.org/base:latest
 
+COPY rootfs.cpio /rootfs.cpio
+
 LABEL com.urunc.unikernel.binary="/unikraft/bin/kernel"
-LABEL "com.urunc.unikernel.cmdline"="/chttp"
+LABEL "com.urunc.unikernel.initrd"="/rootfs.cpio"
 LABEL "com.urunc.unikernel.unikernelType"="unikraft"
 LABEL "com.urunc.unikernel.hypervisor"="qemu"
+
+CMD ["/chttp"]
 ```
 
 ## Using a `bunnyfile`
@@ -84,7 +88,7 @@ kernel:
   from: unikraft.org/base:latest
   path: /unikraft/bin/kernel
 
-cmdline: /chttp
+cmd: ["/chttp"]
 ```
 
 With the above bunnyfile`, `bunny` will build the rootfs of Unikraft as a cpio

--- a/examples/Nginx_Unikraft.md
+++ b/examples/Nginx_Unikraft.md
@@ -1,6 +1,6 @@
 # Packaging a Unikraft unikernel with `bunny`
 
-For this example, we will use an existing [Unikraft](unikraft.org) Unikernel
+For this example, we will use an existing [Unikraft](https://unikraft.org/) Unikernel
 image from [Unikraft's catalog](https://github.com/unikraft/catalog), we can
 transform it to an image that [urunc](https://github.com/nubificus/urunc) can
 execute with `bunny`. The respective `Containerfile` that we would use with
@@ -11,9 +11,10 @@ execute with `bunny`. The respective `Containerfile` that we would use with
 FROM unikraft.org/nginx:1.15
 
 LABEL com.urunc.unikernel.binary="/unikraft/bin/kernel"
-LABEL "com.urunc.unikernel.cmdline"="nginx -c /nginx/conf/nginx.conf"
 LABEL "com.urunc.unikernel.unikernelType"="unikraft"
 LABEL "com.urunc.unikernel.hypervisor"="qemu"
+
+CMD ["-c", "/nginx/conf/nginx.conf"]
 ```
 
 In order to use `bunny`, instead, we need to specify the
@@ -33,7 +34,7 @@ kernel:
   from: unikraft.org/nginx:1.15
   path: /unikraft/bin/kernel
 
-cmdline: nginx -c /nginx/conf/nginx.conf
+cmd: ["-c", "/nginx/conf/nginx.conf"]
 ```
 
 ## Building the image with bunny as buildkit's frontend

--- a/examples/Redis_Rumprun.md
+++ b/examples/Redis_Rumprun.md
@@ -11,16 +11,18 @@ The respective `Containerfile` that we would use with
 [bima](https://github.com/nubificus/bima) would be:
 
 ```
-#syntax=harbor.nbfc.io/nubificus/pun:latest
+#syntax=harbor.nbfc.io/nubificus/bunny:latest
 FROM scratch
 
 COPY redis.hvt /unikernel/redis.hvt
-COPY redis.conf /conf/redis.conf
+COPY /conf /
 
 LABEL com.urunc.unikernel.binary=/unikernel/redis.hvt
-LABEL "com.urunc.unikernel.cmdline"="redis-server /data/conf/redis.conf"
 LABEL "com.urunc.unikernel.unikernelType"="rumprun"
 LABEL "com.urunc.unikernel.hypervisor"="hvt"
+LABEL "com.urunc.unikernel.mountRootfs"="true"
+
+CMD ["redis-server", "/data/conf/redis.conf"]
 ```
 
 In order to use `bunny`, instead, we need to specify the
@@ -40,13 +42,13 @@ rootfs:
   from: scratch
   type: raw
   include:
-  - redis.conf:/data/conf/redis.conf
+  - conf/:/conf
 
 kernel:
   from: local
   path: redis.hvt
 
-cmdline: "redis-server /data/conf/redis.conf"
+cmd: ["redis-server", "/data/conf/redis.conf"]
 ```
 
 > **NOTE**: Since we use the raw type for rootfs, all the files in the include list

--- a/hops/image_config.go
+++ b/hops/image_config.go
@@ -72,7 +72,7 @@ func (rc *ResultAndConfig) GetBaseConfig(ctx context.Context, c client.Client, r
 	return nil
 }
 
-func (rc *ResultAndConfig) UpdateConfig(annots map[string]string) {
+func (rc *ResultAndConfig) UpdateConfig(annots map[string]string, cmd []string) {
 	plat := ocispecs.Platform{
 		Architecture: runtime.GOARCH,
 		OS:           "linux",
@@ -86,7 +86,7 @@ func (rc *ResultAndConfig) UpdateConfig(annots map[string]string) {
 	rc.OCIConfig.Platform = plat
 	rc.OCIConfig.RootFS = rfs
 	// Overwrite Cmd and entrypoint based on the values of bunnyfile
-	rc.OCIConfig.Config.Cmd = strings.Fields(annots["com.urunc.unikernel.cmdline"])
+	rc.OCIConfig.Config.Cmd = cmd
 	rc.OCIConfig.Config.Entrypoint = []string{}
 
 	if rc.OCIConfig.Config.Labels == nil {

--- a/hops/package.go
+++ b/hops/package.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/moby/buildkit/client/llb"
 )
@@ -55,7 +56,8 @@ type Hops struct {
 	Platform Platform `yaml:"platforms"`
 	Rootfs   Rootfs   `yaml:"rootfs"`
 	Kernel   Kernel   `yaml:"kernel"`
-	Cmd      string   `yaml:"cmdline"`
+	Cmdline  string   `yaml:"cmdline"`
+	Cmd      []string `yaml:"cmd"`
 }
 
 // A struct to represent a copy operation in the final image
@@ -76,7 +78,7 @@ type PackConfig struct {
 	// The Entrypoint of the container image
 	Entrypoint []string
 	// The arguments of the entrypoint
-	Cmd string
+	Cmd []string
 }
 
 type PackInstructions struct {
@@ -254,10 +256,10 @@ func (i *PackInstructions) SetBaseAndGetPaths(kEntry *PackEntry, rEntry *PackEnt
 
 // SetAnnotations set all annotations required for urunc.
 // It returns an error if something went wrong
-func (i *PackInstructions) SetAnnotations(p Platform, cmd string, kernelPath string, rootfsPath string, rootfsType string) error {
+func (i *PackInstructions) SetAnnotations(p Platform, cmd []string, kernelPath string, rootfsPath string, rootfsType string) error {
 	// Set basic annotations for urunc's functionality
 	i.Annots["com.urunc.unikernel.unikernelType"] = p.Framework
-	i.Annots["com.urunc.unikernel.cmdline"] = cmd
+	i.Annots["com.urunc.unikernel.cmdline"] = strings.Join(cmd, " ")
 	i.Annots["com.urunc.unikernel.hypervisor"] = p.Monitor
 	i.Annots["com.urunc.unikernel.binary"] = kernelPath
 	// Disable mountRootfs by default and enable it only when rootfs is raw.
@@ -285,7 +287,7 @@ func (i *PackInstructions) SetAnnotations(p Platform, cmd string, kernelPath str
 
 // UpdateConfig fills all the information given by the user for the
 // fileds in PackConfig.
-func (i *PackInstructions) UpdateConfig(cmd string, p Platform) {
+func (i *PackInstructions) UpdateConfig(cmd []string, p Platform) {
 	i.Config.Cmd = cmd
 	i.Config.Monitor = p.Monitor
 }

--- a/hops/package_test.go
+++ b/hops/package_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/moby/buildkit/client/llb"
@@ -249,7 +250,7 @@ func TestPackSetAnnotations(t *testing.T) {
 	type testInfo struct {
 		name        string
 		version     string
-		cmd         string
+		cmd         []string
 		kPath       string
 		rPath       string
 		rType       string
@@ -259,21 +260,21 @@ func TestPackSetAnnotations(t *testing.T) {
 	tests := []testInfo{
 		{
 			name:        "Valid without version and rootfs",
-			cmd:         "cli",
+			cmd:         []string{"cli"},
 			kPath:       "kernel",
 			expectError: false,
 		},
 		{
 			name:        "Valid with version but without rootfs",
 			version:     "v0.1.1",
-			cmd:         "cli",
+			cmd:         []string{"cli"},
 			kPath:       "kernel",
 			expectError: false,
 		},
 		{
 			name:        "Valid with version and initrd rootfs",
 			version:     "v0.1.1",
-			cmd:         "cli",
+			cmd:         []string{"cli"},
 			kPath:       "kernel",
 			rPath:       "kernel",
 			rType:       "initrd",
@@ -282,7 +283,7 @@ func TestPackSetAnnotations(t *testing.T) {
 		{
 			name:        "Valid with version and raw rootfs",
 			version:     "v0.1.1",
-			cmd:         "cli",
+			cmd:         []string{"cli"},
 			kPath:       "kernel",
 			rType:       "raw",
 			expectError: false,
@@ -290,7 +291,7 @@ func TestPackSetAnnotations(t *testing.T) {
 		{
 			name:        "Invalid rootfs type",
 			version:     "v0.1.1",
-			cmd:         "cli",
+			cmd:         []string{"cli"},
 			kPath:       "kernel",
 			rType:       "foo",
 			expectError: true,
@@ -317,7 +318,7 @@ func TestPackSetAnnotations(t *testing.T) {
 				require.Equal(t, p.Framework, i.Annots["com.urunc.unikernel.unikernelType"])
 				require.Equal(t, p.Monitor, i.Annots["com.urunc.unikernel.hypervisor"])
 				require.Equal(t, p.Version, i.Annots["com.urunc.unikernel.unikernelVersion"])
-				require.Equal(t, tc.cmd, i.Annots["com.urunc.unikernel.cmdline"])
+				require.Equal(t, strings.Join(tc.cmd, " "), i.Annots["com.urunc.unikernel.cmdline"])
 				require.Equal(t, tc.kPath, i.Annots["com.urunc.unikernel.binary"])
 				if tc.rType == "raw" {
 					require.Equal(t, "true", i.Annots["com.urunc.unikernel.mountRootfs"])
@@ -628,7 +629,7 @@ func TestPackToPack(t *testing.T) {
 				From: "local",
 				Path: "kernel",
 			},
-			Cmd: "cmd",
+			Cmd: []string{"cmd"},
 		}
 		i, err := ToPack(hops, "context")
 		require.NoError(t, err)
@@ -636,7 +637,7 @@ func TestPackToPack(t *testing.T) {
 		require.Equal(t, "false", i.Annots["com.urunc.unikernel.mountRootfs"])
 		require.Equal(t, hops.Platform.Framework, i.Annots["com.urunc.unikernel.unikernelType"])
 		require.Equal(t, hops.Platform.Monitor, i.Annots["com.urunc.unikernel.hypervisor"])
-		require.Equal(t, hops.Cmd, i.Annots["com.urunc.unikernel.cmdline"])
+		require.Equal(t, strings.Join(hops.Cmd, " "), i.Annots["com.urunc.unikernel.cmdline"])
 		require.Equal(t, DefaultKernelPath, i.Annots["com.urunc.unikernel.binary"])
 		require.Empty(t, i.Annots["com.urunc.unikernel.initrd"])
 		require.Empty(t, i.Annots["com.urunc.unikernel.unikernelVersion"])
@@ -668,7 +669,7 @@ func TestPackToPack(t *testing.T) {
 				From: "harbor.nbfc.io/foo",
 				Path: "/kernel",
 			},
-			Cmd: "cmd",
+			Cmd: []string{"cmd"},
 		}
 		i, err := ToPack(hops, "foo")
 		require.NoError(t, err)
@@ -676,7 +677,7 @@ func TestPackToPack(t *testing.T) {
 		require.Equal(t, "false", i.Annots["com.urunc.unikernel.mountRootfs"])
 		require.Equal(t, hops.Platform.Framework, i.Annots["com.urunc.unikernel.unikernelType"])
 		require.Equal(t, hops.Platform.Monitor, i.Annots["com.urunc.unikernel.hypervisor"])
-		require.Equal(t, hops.Cmd, i.Annots["com.urunc.unikernel.cmdline"])
+		require.Equal(t, strings.Join(hops.Cmd, " "), i.Annots["com.urunc.unikernel.cmdline"])
 		require.Equal(t, hops.Kernel.Path, i.Annots["com.urunc.unikernel.binary"])
 		require.Empty(t, i.Annots["com.urunc.unikernel.initrd"])
 		require.Empty(t, i.Annots["com.urunc.unikernel.unikernelVersion"])
@@ -705,7 +706,7 @@ func TestPackToPack(t *testing.T) {
 				From: "local",
 				Path: "rootfs",
 			},
-			Cmd: "cmd",
+			Cmd: []string{"cmd"},
 		}
 		i, err := ToPack(hops, "context")
 		require.NoError(t, err)
@@ -713,7 +714,7 @@ func TestPackToPack(t *testing.T) {
 		require.Equal(t, "false", i.Annots["com.urunc.unikernel.mountRootfs"])
 		require.Equal(t, hops.Platform.Framework, i.Annots["com.urunc.unikernel.unikernelType"])
 		require.Equal(t, hops.Platform.Monitor, i.Annots["com.urunc.unikernel.hypervisor"])
-		require.Equal(t, hops.Cmd, i.Annots["com.urunc.unikernel.cmdline"])
+		require.Equal(t, strings.Join(hops.Cmd, " "), i.Annots["com.urunc.unikernel.cmdline"])
 		require.Equal(t, DefaultKernelPath, i.Annots["com.urunc.unikernel.binary"])
 		require.Equal(t, DefaultRootfsPath, i.Annots["com.urunc.unikernel.initrd"])
 		require.Empty(t, i.Annots["com.urunc.unikernel.unikernelVersion"])
@@ -759,7 +760,7 @@ func TestPackToPack(t *testing.T) {
 				Path: "rootfs",
 				Type: "initrd",
 			},
-			Cmd: "cmd",
+			Cmd: []string{"cmd"},
 		}
 		i, err := ToPack(hops, "context")
 		require.NoError(t, err)
@@ -768,7 +769,7 @@ func TestPackToPack(t *testing.T) {
 		require.Equal(t, hops.Platform.Framework, i.Annots["com.urunc.unikernel.unikernelType"])
 		require.Equal(t, hops.Platform.Monitor, i.Annots["com.urunc.unikernel.hypervisor"])
 		require.Equal(t, hops.Platform.Version, i.Annots["com.urunc.unikernel.unikernelVersion"])
-		require.Equal(t, hops.Cmd, i.Annots["com.urunc.unikernel.cmdline"])
+		require.Equal(t, strings.Join(hops.Cmd, " "), i.Annots["com.urunc.unikernel.cmdline"])
 		require.Equal(t, DefaultKernelPath, i.Annots["com.urunc.unikernel.binary"])
 		require.Equal(t, DefaultRootfsPath, i.Annots["com.urunc.unikernel.initrd"])
 		require.Empty(t, i.Annots["com.urunc.unikernel.blkMntPoint"])
@@ -813,7 +814,7 @@ func TestPackToPack(t *testing.T) {
 				Path: "rootfs",
 				Type: "initrd",
 			},
-			Cmd: "cmd",
+			Cmd: []string{"cmd"},
 		}
 		i, err := ToPack(hops, "context")
 		require.NoError(t, err)
@@ -821,7 +822,7 @@ func TestPackToPack(t *testing.T) {
 		require.Equal(t, "false", i.Annots["com.urunc.unikernel.mountRootfs"])
 		require.Equal(t, hops.Platform.Framework, i.Annots["com.urunc.unikernel.unikernelType"])
 		require.Equal(t, hops.Platform.Monitor, i.Annots["com.urunc.unikernel.hypervisor"])
-		require.Equal(t, hops.Cmd, i.Annots["com.urunc.unikernel.cmdline"])
+		require.Equal(t, strings.Join(hops.Cmd, " "), i.Annots["com.urunc.unikernel.cmdline"])
 		require.Equal(t, DefaultKernelPath, i.Annots["com.urunc.unikernel.binary"])
 		require.Equal(t, hops.Rootfs.Path, i.Annots["com.urunc.unikernel.initrd"])
 		require.Empty(t, i.Annots["com.urunc.unikernel.unikernelVersion"])
@@ -858,7 +859,7 @@ func TestPackToPack(t *testing.T) {
 			Rootfs: Rootfs{
 				From: "harbor.nbfc.io/foo",
 			},
-			Cmd: "cmd",
+			Cmd: []string{"cmd"},
 		}
 		i, err := ToPack(hops, "context")
 		require.NoError(t, err)
@@ -866,7 +867,7 @@ func TestPackToPack(t *testing.T) {
 		require.Equal(t, "true", i.Annots["com.urunc.unikernel.mountRootfs"])
 		require.Equal(t, hops.Platform.Framework, i.Annots["com.urunc.unikernel.unikernelType"])
 		require.Equal(t, hops.Platform.Monitor, i.Annots["com.urunc.unikernel.hypervisor"])
-		require.Equal(t, hops.Cmd, i.Annots["com.urunc.unikernel.cmdline"])
+		require.Equal(t, strings.Join(hops.Cmd, " "), i.Annots["com.urunc.unikernel.cmdline"])
 		require.Equal(t, DefaultKernelPath, i.Annots["com.urunc.unikernel.binary"])
 		require.Empty(t, i.Annots["com.urunc.unikernel.initrd"])
 		require.Empty(t, i.Annots["com.urunc.unikernel.unikernelVersion"])
@@ -903,7 +904,7 @@ func TestPackToPack(t *testing.T) {
 				From:     "scratch",
 				Includes: []string{"foo:bar"},
 			},
-			Cmd: "cmd",
+			Cmd: []string{"cmd"},
 		}
 		i, err := ToPack(hops, "context")
 		require.NoError(t, err)
@@ -911,7 +912,7 @@ func TestPackToPack(t *testing.T) {
 		require.Equal(t, "false", i.Annots["com.urunc.unikernel.mountRootfs"])
 		require.Equal(t, hops.Platform.Framework, i.Annots["com.urunc.unikernel.unikernelType"])
 		require.Equal(t, hops.Platform.Monitor, i.Annots["com.urunc.unikernel.hypervisor"])
-		require.Equal(t, hops.Cmd, i.Annots["com.urunc.unikernel.cmdline"])
+		require.Equal(t, strings.Join(hops.Cmd, " "), i.Annots["com.urunc.unikernel.cmdline"])
 		require.Equal(t, DefaultKernelPath, i.Annots["com.urunc.unikernel.binary"])
 		require.Equal(t, DefaultRootfsPath, i.Annots["com.urunc.unikernel.initrd"])
 		require.Empty(t, i.Annots["com.urunc.unikernel.unikernelVersion"])
@@ -960,7 +961,7 @@ func TestPackToPack(t *testing.T) {
 				From:     "scratch",
 				Includes: []string{"foo:bar"},
 			},
-			Cmd: "cmd",
+			Cmd: []string{"cmd"},
 		}
 		i, err := ToPack(hops, "context")
 		require.NoError(t, err)
@@ -968,7 +969,7 @@ func TestPackToPack(t *testing.T) {
 		require.Equal(t, "true", i.Annots["com.urunc.unikernel.mountRootfs"])
 		require.Equal(t, hops.Platform.Framework, i.Annots["com.urunc.unikernel.unikernelType"])
 		require.Equal(t, hops.Platform.Monitor, i.Annots["com.urunc.unikernel.hypervisor"])
-		require.Equal(t, hops.Cmd, i.Annots["com.urunc.unikernel.cmdline"])
+		require.Equal(t, strings.Join(hops.Cmd, " "), i.Annots["com.urunc.unikernel.cmdline"])
 		require.Equal(t, DefaultKernelPath, i.Annots["com.urunc.unikernel.binary"])
 		require.Empty(t, i.Annots["com.urunc.unikernel.initrd"])
 		require.Empty(t, i.Annots["com.urunc.unikernel.unikernelVersion"])
@@ -1008,7 +1009,7 @@ func TestPackToPack(t *testing.T) {
 				From: "local",
 				Path: "rootfs",
 			},
-			Cmd: "cmd",
+			Cmd: []string{"cmd"},
 		}
 		i, err := ToPack(hops, "context")
 		require.NoError(t, err)
@@ -1016,7 +1017,7 @@ func TestPackToPack(t *testing.T) {
 		require.Equal(t, "false", i.Annots["com.urunc.unikernel.mountRootfs"])
 		require.Equal(t, hops.Platform.Framework, i.Annots["com.urunc.unikernel.unikernelType"])
 		require.Equal(t, hops.Platform.Monitor, i.Annots["com.urunc.unikernel.hypervisor"])
-		require.Equal(t, hops.Cmd, i.Annots["com.urunc.unikernel.cmdline"])
+		require.Equal(t, strings.Join(hops.Cmd, " "), i.Annots["com.urunc.unikernel.cmdline"])
 		require.Equal(t, hops.Kernel.Path, i.Annots["com.urunc.unikernel.binary"])
 		require.Equal(t, DefaultRootfsPath, i.Annots["com.urunc.unikernel.initrd"])
 		require.Empty(t, i.Annots["com.urunc.unikernel.unikernelVersion"])
@@ -1055,7 +1056,7 @@ func TestPackToPack(t *testing.T) {
 				Path: "rootfs",
 				Type: "initrd",
 			},
-			Cmd: "cmd",
+			Cmd: []string{"cmd"},
 		}
 		i, err := ToPack(hops, "context")
 		require.NoError(t, err)
@@ -1063,7 +1064,7 @@ func TestPackToPack(t *testing.T) {
 		require.Equal(t, "false", i.Annots["com.urunc.unikernel.mountRootfs"])
 		require.Equal(t, hops.Platform.Framework, i.Annots["com.urunc.unikernel.unikernelType"])
 		require.Equal(t, hops.Platform.Monitor, i.Annots["com.urunc.unikernel.hypervisor"])
-		require.Equal(t, hops.Cmd, i.Annots["com.urunc.unikernel.cmdline"])
+		require.Equal(t, strings.Join(hops.Cmd, " "), i.Annots["com.urunc.unikernel.cmdline"])
 		require.Equal(t, DefaultKernelPath, i.Annots["com.urunc.unikernel.binary"])
 		require.Equal(t, hops.Rootfs.Path, i.Annots["com.urunc.unikernel.initrd"])
 		require.Empty(t, i.Annots["com.urunc.unikernel.unikernelVersion"])
@@ -1100,7 +1101,7 @@ func TestPackToPack(t *testing.T) {
 			Rootfs: Rootfs{
 				From: "harbor.nbfc.io/foo",
 			},
-			Cmd: "cmd",
+			Cmd: []string{"cmd"},
 		}
 		i, err := ToPack(hops, "context")
 		require.NoError(t, err)
@@ -1108,7 +1109,7 @@ func TestPackToPack(t *testing.T) {
 		require.Equal(t, "true", i.Annots["com.urunc.unikernel.mountRootfs"])
 		require.Equal(t, hops.Platform.Framework, i.Annots["com.urunc.unikernel.unikernelType"])
 		require.Equal(t, hops.Platform.Monitor, i.Annots["com.urunc.unikernel.hypervisor"])
-		require.Equal(t, hops.Cmd, i.Annots["com.urunc.unikernel.cmdline"])
+		require.Equal(t, strings.Join(hops.Cmd, " "), i.Annots["com.urunc.unikernel.cmdline"])
 		require.Equal(t, DefaultKernelPath, i.Annots["com.urunc.unikernel.binary"])
 		require.Empty(t, i.Annots["com.urunc.unikernel.initrd"])
 		require.Empty(t, i.Annots["com.urunc.unikernel.unikernelVersion"])
@@ -1145,7 +1146,7 @@ func TestPackToPack(t *testing.T) {
 				From:     "scratch",
 				Includes: []string{"foo:bar"},
 			},
-			Cmd: "cmd",
+			Cmd: []string{"cmd"},
 		}
 		i, err := ToPack(hops, "context")
 		require.NoError(t, err)
@@ -1153,7 +1154,7 @@ func TestPackToPack(t *testing.T) {
 		require.Equal(t, "false", i.Annots["com.urunc.unikernel.mountRootfs"])
 		require.Equal(t, hops.Platform.Framework, i.Annots["com.urunc.unikernel.unikernelType"])
 		require.Equal(t, hops.Platform.Monitor, i.Annots["com.urunc.unikernel.hypervisor"])
-		require.Equal(t, hops.Cmd, i.Annots["com.urunc.unikernel.cmdline"])
+		require.Equal(t, strings.Join(hops.Cmd, " "), i.Annots["com.urunc.unikernel.cmdline"])
 		require.Equal(t, hops.Kernel.Path, i.Annots["com.urunc.unikernel.binary"])
 		require.Equal(t, DefaultRootfsPath, i.Annots["com.urunc.unikernel.initrd"])
 		require.Empty(t, i.Annots["com.urunc.unikernel.unikernelVersion"])
@@ -1196,7 +1197,7 @@ func TestPackToPack(t *testing.T) {
 				Path: "kernel",
 				Type: "foo",
 			},
-			Cmd: "cmd",
+			Cmd: []string{"cmd"},
 		}
 		i, err := ToPack(hops, "context")
 		require.ErrorContains(t, err, "Error handling rootfs entry")
@@ -1217,7 +1218,7 @@ func TestPackToPack(t *testing.T) {
 	//		Rootfs: Rootfs{
 	//			From: "harbor.nbfc.io/foo",
 	//		},
-	//		Cmd: "cmd",
+	//		Cmd: []string{"cmd"},
 	//	}
 	//	i, err := ToPack(hops, "context")
 	//	require.ErrorContains(t, err, "unikraft does not support raw rootfs")
@@ -1237,7 +1238,7 @@ func TestPackToPack(t *testing.T) {
 				From:     "scratch",
 				Includes: []string{":bar"},
 			},
-			Cmd: "cmd",
+			Cmd: []string{"cmd"},
 		}
 		i, err := ToPack(hops, "context")
 		require.ErrorContains(t, err, "Error handling rootfs entry")
@@ -1251,7 +1252,7 @@ func TestPackToPack(t *testing.T) {
 			},
 			Kernel: Kernel{},
 			Rootfs: Rootfs{},
-			Cmd:    "cmd",
+			Cmd:    []string{"cmd"},
 		}
 		i, err := ToPack(hops, "context")
 		require.ErrorContains(t, err, "Error choosing base state")

--- a/hops/parse_file_test.go
+++ b/hops/parse_file_test.go
@@ -177,6 +177,7 @@ cmdline: "foo bar"
 				require.Nil(t, h)
 				require.Contains(t, err.Error(), tc.errorText)
 			} else {
+				// TODO: Update test to check rootfs and cmdline
 				require.NoError(t, err)
 				require.NotNil(t, h)
 			}


### PR DESCRIPTION
Instead of getting all cmdline arguments as a single string and then separate it based on spaces, let the user define each one argument as a separate string in an array of strings. Therefore, replace `cmdline` filed in bunnyfile with `cmd`, which now accepts an array of strings, instead of a single string. Furthermore, add support for the `CMD` instruction in Containerfile-like files to slowly replace the cmdline annotation.  

This change will eliminate issues where we have multi-word arguments given by the user, but they were breaking down in separate arguments.
    
Also, only for backwards compatibility and for a short period of time (e.g. next release), maintain the old single string cmdline field in bunnyfile. However,, it should no longer be used.
