### PR TITLE
Add support for entrypoint in all file formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ kernel:                                         # [5] Specify a prebuilt kernel 
   from: local                                   # [5a] Specify the source of a prebuilt kernel.
   path: local                                   # [5b] The path where the kernel image resides.
 
-cmd: ["hello"]                                  # [6] The command line arguments of the app.
+cmd: ["app"]                                    # [6] The command line arguments of the app
+entrypoint: ["init"]                            # [7] The entrypoint of the container
 
 ```
 
@@ -85,7 +86,8 @@ The fields of `bunnyfile` in more details:
 | 5  | Information about a prebuilt kernel | no | - | - |
 | 5a | The location where the prebuilt kernel resides | no | "local", "OCI image" | - |
 | 5b | The path relative to the `from` field where a kernel binary resides | yes, if `from` is set  | "local", "OCI image" | - |
-| 6  | The command line of the application | no | string | - |
+| 6  | The command line of the application | no | []string | - |
+| 7  | The entrypoint of the container | no | []string | - |
 
 ### The `rootfs` field
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -146,7 +146,7 @@ func bunnyBuilder(ctx context.Context, c client.Client) (*client.Result, error) 
 
 	// Set some default values in the Image config
 	// and add cmdline and Labels
-	rc.UpdateConfig(packInst.Annots, packInst.Config.Cmd)
+	rc.UpdateConfig(packInst.Annots, packInst.Config.Cmd, packInst.Config.Entrypoint)
 
 	// Apply annotations and the new config to the solver's result
 	err = rc.ApplyConfig(packInst.Annots)

--- a/hops/image_config.go
+++ b/hops/image_config.go
@@ -72,7 +72,7 @@ func (rc *ResultAndConfig) GetBaseConfig(ctx context.Context, c client.Client, r
 	return nil
 }
 
-func (rc *ResultAndConfig) UpdateConfig(annots map[string]string, cmd []string) {
+func (rc *ResultAndConfig) UpdateConfig(annots map[string]string, cmd []string, entryp []string) {
 	plat := ocispecs.Platform{
 		Architecture: runtime.GOARCH,
 		OS:           "linux",
@@ -87,7 +87,7 @@ func (rc *ResultAndConfig) UpdateConfig(annots map[string]string, cmd []string) 
 	rc.OCIConfig.RootFS = rfs
 	// Overwrite Cmd and entrypoint based on the values of bunnyfile
 	rc.OCIConfig.Config.Cmd = cmd
-	rc.OCIConfig.Config.Entrypoint = []string{}
+	rc.OCIConfig.Config.Entrypoint = entryp
 
 	if rc.OCIConfig.Config.Labels == nil {
 		rc.OCIConfig.Config.Labels = make(map[string]string)

--- a/hops/package.go
+++ b/hops/package.go
@@ -52,12 +52,13 @@ type Kernel struct {
 }
 
 type Hops struct {
-	Version  string   `yaml:"version"`
-	Platform Platform `yaml:"platforms"`
-	Rootfs   Rootfs   `yaml:"rootfs"`
-	Kernel   Kernel   `yaml:"kernel"`
-	Cmdline  string   `yaml:"cmdline"`
-	Cmd      []string `yaml:"cmd"`
+	Version    string   `yaml:"version"`
+	Platform   Platform `yaml:"platforms"`
+	Rootfs     Rootfs   `yaml:"rootfs"`
+	Kernel     Kernel   `yaml:"kernel"`
+	Cmdline    string   `yaml:"cmdline"`
+	Cmd        []string `yaml:"cmd"`
+	Entrypoint []string `yaml:"entrypoint"`
 }
 
 // A struct to represent a copy operation in the final image
@@ -287,8 +288,9 @@ func (i *PackInstructions) SetAnnotations(p Platform, cmd []string, kernelPath s
 
 // UpdateConfig fills all the information given by the user for the
 // fileds in PackConfig.
-func (i *PackInstructions) UpdateConfig(cmd []string, p Platform) {
+func (i *PackInstructions) UpdateConfig(cmd []string, entryp []string, p Platform) {
 	i.Config.Cmd = cmd
+	i.Config.Entrypoint = entryp
 	i.Config.Monitor = p.Monitor
 }
 
@@ -334,7 +336,7 @@ func ToPack(h *Hops, buildContext string) (*PackInstructions, error) {
 		return nil, fmt.Errorf("Error setting annotations: %v", err)
 	}
 
-	instr.UpdateConfig(h.Cmd, h.Platform)
+	instr.UpdateConfig(h.Cmd, h.Entrypoint, h.Platform)
 
 	return instr, nil
 }

--- a/hops/parse_file.go
+++ b/hops/parse_file.go
@@ -115,6 +115,8 @@ func ParseContainerfile(fileBytes []byte, buildContext string) (*PackInstruction
 			}
 		case *instructions.CmdCommand:
 			instr.Config.Cmd = c.CmdLine
+		case *instructions.EntrypointCommand:
+			instr.Config.Entrypoint = c.CmdLine
 		case instructions.Command:
 			// Catch all other commands
 			return nil, fmt.Errorf("Unsupported command: %s", c.Name())


### PR DESCRIPTION
Add support for recognizing and setting an entrypoint in the final container image config. In particular, identify the instruction `ENTRYPOINT` in Containerfile-like syntax and the `entrypoint` field in bunnyfile. In both cases, an array of strings that contain the arguments is expected.