### PR TITLE
Add support for appending environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,12 @@ kernel:                                         # [5] Specify a prebuilt kernel 
   from: local                                   # [5a] Specify the source of a prebuilt kernel.
   path: local                                   # [5b] The path where the kernel image resides.
 
-cmd: ["app"]                                    # [6] The command line arguments of the app
-entrypoint: ["init"]                            # [7] The entrypoint of the container
+envs:                                           # [6] A list with all environment variables
+  - HOME=/home/ubuntu
+
+cmd: ["app"]                                    # [7] The command line arguments of the app
+
+entrypoint: ["init"]                            # [8] The entrypoint of the container
 
 ```
 
@@ -86,8 +90,9 @@ The fields of `bunnyfile` in more details:
 | 5  | Information about a prebuilt kernel | no | - | - |
 | 5a | The location where the prebuilt kernel resides | no | "local", "OCI image" | - |
 | 5b | The path relative to the `from` field where a kernel binary resides | yes, if `from` is set  | "local", "OCI image" | - |
-| 6  | The command line of the application | no | []string | - |
-| 7  | The entrypoint of the container | no | []string | - |
+| 6  | A list of environment variables| no | list of <ENVIRONMENT_VARIABLE>:<VALUE> | - |
+| 7  | The command line of the application | no | []string | - |
+| 8  | The entrypoint of the container | no | []string | - |
 
 ### The `rootfs` field
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -146,7 +146,7 @@ func bunnyBuilder(ctx context.Context, c client.Client) (*client.Result, error) 
 
 	// Set some default values in the Image config
 	// and add cmdline and Labels
-	rc.UpdateConfig(packInst.Annots, packInst.Config.Cmd, packInst.Config.Entrypoint)
+	rc.UpdateConfig(packInst.Annots, packInst.Config.Cmd, packInst.Config.Entrypoint, packInst.Config.EnVars)
 
 	// Apply annotations and the new config to the solver's result
 	err = rc.ApplyConfig(packInst.Annots)

--- a/hops/image_config.go
+++ b/hops/image_config.go
@@ -72,7 +72,7 @@ func (rc *ResultAndConfig) GetBaseConfig(ctx context.Context, c client.Client, r
 	return nil
 }
 
-func (rc *ResultAndConfig) UpdateConfig(annots map[string]string, cmd []string, entryp []string) {
+func (rc *ResultAndConfig) UpdateConfig(annots map[string]string, cmd []string, entryp []string, ev []string) {
 	plat := ocispecs.Platform{
 		Architecture: runtime.GOARCH,
 		OS:           "linux",
@@ -88,6 +88,7 @@ func (rc *ResultAndConfig) UpdateConfig(annots map[string]string, cmd []string, 
 	// Overwrite Cmd and entrypoint based on the values of bunnyfile
 	rc.OCIConfig.Config.Cmd = cmd
 	rc.OCIConfig.Config.Entrypoint = entryp
+	rc.OCIConfig.Config.Env = append(rc.OCIConfig.Config.Env, ev...)
 
 	if rc.OCIConfig.Config.Labels == nil {
 		rc.OCIConfig.Config.Labels = make(map[string]string)

--- a/hops/package.go
+++ b/hops/package.go
@@ -59,6 +59,7 @@ type Hops struct {
 	Cmdline    string   `yaml:"cmdline"`
 	Cmd        []string `yaml:"cmd"`
 	Entrypoint []string `yaml:"entrypoint"`
+	Envs       []string `yaml:"envs"`
 }
 
 // A struct to represent a copy operation in the final image
@@ -80,6 +81,8 @@ type PackConfig struct {
 	Entrypoint []string
 	// The arguments of the entrypoint
 	Cmd []string
+	// The environment variables set by the user
+	EnVars []string
 }
 
 type PackInstructions struct {
@@ -288,10 +291,11 @@ func (i *PackInstructions) SetAnnotations(p Platform, cmd []string, kernelPath s
 
 // UpdateConfig fills all the information given by the user for the
 // fileds in PackConfig.
-func (i *PackInstructions) UpdateConfig(cmd []string, entryp []string, p Platform) {
+func (i *PackInstructions) UpdateConfig(cmd []string, entryp []string, ev []string, p Platform) {
 	i.Config.Cmd = cmd
 	i.Config.Entrypoint = entryp
 	i.Config.Monitor = p.Monitor
+	i.Config.EnVars = ev
 }
 
 // ToPack converts Hops into PackInstructions
@@ -336,7 +340,7 @@ func ToPack(h *Hops, buildContext string) (*PackInstructions, error) {
 		return nil, fmt.Errorf("Error setting annotations: %v", err)
 	}
 
-	instr.UpdateConfig(h.Cmd, h.Entrypoint, h.Platform)
+	instr.UpdateConfig(h.Cmd, h.Entrypoint, h.Envs, h.Platform)
 
 	return instr, nil
 }

--- a/hops/parse_file.go
+++ b/hops/parse_file.go
@@ -117,6 +117,11 @@ func ParseContainerfile(fileBytes []byte, buildContext string) (*PackInstruction
 			instr.Config.Cmd = c.CmdLine
 		case *instructions.EntrypointCommand:
 			instr.Config.Entrypoint = c.CmdLine
+		case *instructions.EnvCommand:
+			for _, kvp := range c.Env {
+				eVar := kvp.Key + "=" + kvp.Value
+				instr.Config.EnVars = append(instr.Config.EnVars, eVar)
+			}
 		case instructions.Command:
 			// Catch all other commands
 			return nil, fmt.Errorf("Unsupported command: %s", c.Name())


### PR DESCRIPTION
Add support for adding or appending environment variables in the final container image. The users can use both bunnyfile and Containerfile-like syntax files in order to set environment variables.

In the case of bunnyfile the environment variables are set under the field `envs` as a list.

In the case of Containerfile-like syntax files, users can use the `ENV` instruction as normally.