### PR TITLE
Add support for appending files in raw rootfs

### DIFF
--- a/hops/frameworks.go
+++ b/hops/frameworks.go
@@ -26,5 +26,6 @@ type Framework interface {
 	SupportsMonitor(string) bool
 	SupportsArch(string) bool
 	CreateRootfs(string) (llb.State, error)
+	UpdateRootfs(string) (llb.State, error)
 	BuildKernel(string) llb.State
 }

--- a/hops/generic.go
+++ b/hops/generic.go
@@ -91,6 +91,20 @@ func (i *GenericInfo) CreateRootfs(buildContext string) (llb.State, error) {
 	}
 }
 
+func (i *GenericInfo) UpdateRootfs(buildContext string) (llb.State, error) {
+	local := llb.Local(buildContext)
+	base := llb.Image(i.Rootfs.From)
+	switch i.Rootfs.Type {
+	case "initrd":
+		return llb.Scratch(), fmt.Errorf("Can not update an initrd rootfs")
+	case "raw":
+		return FilesLLB(i.Rootfs.Includes, local, base)
+	default:
+		// We should never reach this point
+		return llb.Scratch(), fmt.Errorf("Unsupported rootfs type")
+	}
+}
+
 func (i *GenericInfo) BuildKernel(_ string) llb.State {
 	return llb.Scratch()
 }

--- a/hops/validate.go
+++ b/hops/validate.go
@@ -78,9 +78,14 @@ func ValidateRootfs(rootfs Rootfs) error {
 		return fmt.Errorf("If type of rootfs is raw, then from can not be local")
 	}
 
-	if len(rootfs.Includes) > 0 && rootfs.From != "" && rootfs.From != "scratch" {
-		return fmt.Errorf("Adding files to an existing rootfs is not yet supported")
+	if len(rootfs.Includes) > 0 && rootfs.From == "local" {
+		return fmt.Errorf("Invalid combination of includes and from fields")
 	}
+
+	if len(rootfs.Includes) > 0 && rootfs.From != "" && rootfs.From != "scratch" && rootfs.Type != "raw" {
+		return fmt.Errorf("Adding files to an existing non-raw rootfs is not yet supported")
+	}
+
 	for _, file := range rootfs.Includes {
 		parts := strings.Split(file, ":")
 		if len(parts) < 1 || len(parts[0]) == 0 {

--- a/hops/validate_test.go
+++ b/hops/validate_test.go
@@ -155,6 +155,12 @@ func TestValidateBunnyfileRootfs(t *testing.T) {
 			errorText:   "",
 		},
 		{
+			name:        "Valid from registry with includes",
+			input:       "harbor.nbfc.io/path//foo:bar",
+			expectError: true,
+			errorText:   "",
+		},
+		{
 			name:        "Invalid empty from, non-empty path",
 			input:       "/path//",
 			expectError: true,
@@ -182,7 +188,13 @@ func TestValidateBunnyfileRootfs(t *testing.T) {
 			name:        "Invalid from local with includes",
 			input:       "local/path//foo:bar",
 			expectError: true,
-			errorText:   "Adding files to an existing rootfs is not yet",
+			errorText:   "Invalid combination of includes and from fields",
+		},
+		{
+			name:        "Invalid from registry with type initrd and includes",
+			input:       "harbor.nbfc.io/path/initrd/foo:bar",
+			expectError: true,
+			errorText:   "Adding files to an existing non-raw rootfs is not yet supported",
 		},
 		{
 			name:        "Invalid include with no source",


### PR DESCRIPTION
Add initial support for appending files in an existing rootfs. For the time being this functionality only works for raw rootfs type and the user needs to specifically declare the rootfs type in bunnyfile.