### PR TITLE
Do not overwrite with empty values the cmd and entrypoint

### DIFF
--- a/hops/image_config.go
+++ b/hops/image_config.go
@@ -85,9 +85,12 @@ func (rc *ResultAndConfig) UpdateConfig(annots map[string]string, cmd []string, 
 	// and initialize empty configs.
 	rc.OCIConfig.Platform = plat
 	rc.OCIConfig.RootFS = rfs
-	// Overwrite Cmd and entrypoint based on the values of bunnyfile
-	rc.OCIConfig.Config.Cmd = cmd
-	rc.OCIConfig.Config.Entrypoint = entryp
+	if len(cmd) > 0 {
+		rc.OCIConfig.Config.Cmd = cmd
+	}
+	if len(entryp) > 0 {
+		rc.OCIConfig.Config.Entrypoint = entryp
+	}
 	rc.OCIConfig.Config.Env = append(rc.OCIConfig.Config.Env, ev...)
 
 	if rc.OCIConfig.Config.Labels == nil {

--- a/hops/parse_file.go
+++ b/hops/parse_file.go
@@ -63,7 +63,7 @@ func ParseBunnyfile(fileBytes []byte) (*Hops, error) {
 	// TODO: Remove this in next release.
 	// Keep backwards compatibility and if cmd is empty, then
 	// use cmdline. Otherwise, the Cmdline is ignored.
-	if len(bunnyHops.Cmd) == 0 {
+	if len(bunnyHops.Cmd) == 0 && bunnyHops.Cmdline != "" {
 		bunnyHops.Cmd = strings.Split(bunnyHops.Cmdline, " ")
 	}
 
@@ -141,7 +141,7 @@ func ParseContainerfile(fileBytes []byte, buildContext string) (*PackInstruction
 	// Keep backwards compatibility and if the CMD in Containerfile
 	// is not set, then the cmdline annotations will be used for the cmd of
 	// the container image.
-	if len(instr.Config.Cmd) == 0 {
+	if len(instr.Config.Cmd) == 0 && instr.Annots["com.urunc.unikernel.cmdline"] != "" {
 		instr.Config.Cmd = strings.Split(instr.Annots["com.urunc.unikernel.cmdline"], " ")
 	}
 


### PR DESCRIPTION
In the case where the user has not specified any cmd or entrypoint in the bunnyfile or the Containerfile, do not overwrite the respective image config values.