### PR TITLE
Add initial support for block type rootfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ field is useful. Users can choose (if they wish) a specific type of rootfs and
 `bunny` will build it. Currently, `bunny` can create the following types:
 
 - **initrd**: A typical cpio file that guests can use as an initial rootfs.
+- **block**: A block image that can be used as a rootfs.
 - **raw**: In this case `bunny` does not build any specific kind of file, but
   instead copies the files, that the user specifies, directly in the OCI image's
   rootfs. This type is useful when we want to pass the entire OCI image's rootfs
@@ -243,18 +244,19 @@ While support for building unikernels is underway, it is currently experimental 
 
 The table below summarizes the current support for various unikernels and frameworks:
 
-| Unikernel  | Build    | Rootfs       |
-|----------- |--------- |------------- |
-| Rumprun    | :hammer: | raw          |
-| Unikraft   | :hammer: | Initrd / raw |
-| MirageOS   | :hammer: | No support   |
-| Mewz       | :hammer: | No support   |
-| Linux      | :hammer: | Initrd / raw |
+| Unikernel  | Build    | Rootfs              |
+|----------- |--------- |-------------------  |
+| Rumprun    | :hammer: | block / raw         |
+| Unikraft   | :hammer: | initrd / raw        |
+| MirageOS   | :hammer: | block /raw          |
+| Mewz       | :hammer: | No support          |
+| Linux      | :hammer: | initrd / block /raw |
 
 
-Even if a framework is not listed above, specifying the rootfs type `bunny` is
-able to create a `raw` or `initrd` root filesystem and subsequently package
-everything as an OCI image with the necessary annotations for urunc
+Even if a framework is not listed above, specifying one of the supported rootfs types
+will be enough for `bunny` to create or handle such a root filesystem
+and subsequently package everything as an OCI image with the necessary
+annotations for urunc
 
 We plan to continuously expand support for additional unikernel frameworks and
 similar technologies. Feel free to [contact](#contact) us for a specific

--- a/hops/generic.go
+++ b/hops/generic.go
@@ -55,6 +55,8 @@ func (i *GenericInfo) SupportsRootfsType(rootfsType string) bool {
 	switch rootfsType {
 	case "initrd":
 		return true
+	case "block":
+		return true
 	case "raw":
 		return true
 	default:
@@ -87,7 +89,7 @@ func (i *GenericInfo) CreateRootfs(buildContext string) (llb.State, error) {
 		return FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
 	default:
 		// We should never reach this point
-		return llb.Scratch(), fmt.Errorf("Unsupported rootfs type")
+		return llb.Scratch(), fmt.Errorf("Unsupported rootfs type %s", i.Rootfs.Type)
 	}
 }
 
@@ -101,7 +103,7 @@ func (i *GenericInfo) UpdateRootfs(buildContext string) (llb.State, error) {
 		return FilesLLB(i.Rootfs.Includes, local, base)
 	default:
 		// We should never reach this point
-		return llb.Scratch(), fmt.Errorf("Unsupported rootfs type")
+		return llb.Scratch(), fmt.Errorf("Unsupported rootfs type %s", i.Rootfs.Type)
 	}
 }
 

--- a/hops/generic_test.go
+++ b/hops/generic_test.go
@@ -101,12 +101,20 @@ func TestGenericGetRootfsType(t *testing.T) {
 
 func TestGenericSupportsRootfsType(t *testing.T) {
 	generic := &GenericInfo{}
-	t.Run("Supported rootfs type", func(t *testing.T) {
+	t.Run("Supported rootfs type initrd", func(t *testing.T) {
 		require.Equal(t, true, generic.SupportsRootfsType("initrd"))
 
 	})
-	t.Run("Unsupported rootfs type", func(t *testing.T) {
+	t.Run("Supported rootfs type block", func(t *testing.T) {
+		require.Equal(t, true, generic.SupportsRootfsType("block"))
+
+	})
+	t.Run("Supported rootfs type raw", func(t *testing.T) {
 		require.Equal(t, true, generic.SupportsRootfsType("raw"))
+
+	})
+	t.Run("Unsupported rootfs type foo", func(t *testing.T) {
+		require.Equal(t, false, generic.SupportsRootfsType("foo"))
 
 	})
 }

--- a/hops/package.go
+++ b/hops/package.go
@@ -121,7 +121,7 @@ func handleRootfs(f Framework, buildContext string, mon string, r Rootfs) (*Pack
 	// Make sure that the specified rootfs type is supported
 	// from the framework.
 	if r.Type != "" && !f.SupportsRootfsType(r.Type) {
-		return nil, fmt.Errorf("Cannot build %s rootfs for %s",
+		return nil, fmt.Errorf("Cannot set %s rootfs type for %s",
 			r.Type, f.Name())
 	}
 
@@ -292,6 +292,13 @@ func (i *PackInstructions) SetAnnotations(p Platform, cmd []string, kernelPath s
 		// no-op
 	case "initrd":
 		i.Annots["com.urunc.unikernel.initrd"] = rootfsPath
+	case "block":
+		i.Annots["com.urunc.unikernel.block"] = rootfsPath
+		i.Annots["com.urunc.unikernel.blkMntPoint"] = "/"
+		// TODO: FInd a better way to set a non-root mountpoint for rumprun
+		if p.Framework == "rumprun" {
+			i.Annots["com.urunc.unikernel.blkMntPoint"] = "/data"
+		}
 	case "raw":
 		i.Annots["com.urunc.unikernel.mountRootfs"] = "true"
 	default:


### PR DESCRIPTION
Allow the definition of block as a rootfs type. This will result on setting the `com.urunc.unikernel.block` and
`com.urunc.unikernel.blkMntPoint` annotations in the images. However, the current implementation does not support the building of block-based rootfs.