### PR TITLE
Add support for including frils from OCI images in the rootfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ rootfs:                                         # [4] (Optional) Specifies the r
   from: local                                   # [4a] (Optional) The source or base of the rootfs.
   path: initrd                                  # [4b] (Required if from is not scratch) The path in the source, where the prebuilt rootfs file resides.
   type: initrd                                  # [4c] (optional) The type of rootfs (e.g. initrd, raw, block)
-  include:                                      # [4d] (Optional) A list of local files to include in the rootfs
-    - src:dst
+  include:                                      # [4d] (Optional) A list of local files to include in the rootfs. Two formats are supported:
+    - src:dst                                   #      Using ':' to separate source and destination.
+    - Source: <src>                             #      Specifying Source and Destination as separate fields in one entry.
+      Destination: <dst>
 
 kernel:                                         # [5] Specify a prebuilt kernel to use
   from: local                                   # [5a] Specify the source of a prebuilt kernel.
@@ -87,7 +89,7 @@ The fields of `bunnyfile` in more details:
 | 4a  | Base image or location containing a rootfs | no | `"scratch"`, `"local"`, `"OCI image"` | `"scratch"` |
 | 4b  | Path to rootfs file (relative to `from`) | yes, if `from == "local"` | file path | - |
 | 4c  | Type of the rootfs | no | `"raw"`, `"initrd"` | platform-dependent |
-| 4d  | Files from build context to include in rootfs | no | list of `build-path:rootfs-path` | - |
+| 4d  | Files from build context to include in rootfs | no | list of `local-path:rootfs-path`or list of specific Source, Destination entries | - |
 | 5   | Prebuilt kernel information | yes | - | - |
 | 5a  | Location of the prebuilt kernel | yes | `"local"`, `"OCI image"` | - |
 | 5b  | Path to kernel binary (relative to `from`) | yes | file path | - |

--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ rootfs:                                         # [4] (Optional) Specifies the r
   from: local                                   # [4a] (Optional) The source or base of the rootfs.
   path: initrd                                  # [4b] (Required if from is not scratch) The path in the source, where the prebuilt rootfs file resides.
   type: initrd                                  # [4c] (optional) The type of rootfs (e.g. initrd, raw, block)
-  include:                                      # [4d] (Optional) A list of local files to include in the rootfs. Two formats are supported:
-    - src:dst                                   #      Using ':' to separate source and destination.
-    - Source: <src>                             #      Specifying Source and Destination as separate fields in one entry.
-      Destination: <dst>
+  include:                                      # [4d] (Optional) A list of files to include in the rootfs. Two formats are supported:
+    - src:dst                                   #      Using ':' to separate source and destination. Only for local files.
+    - from: <nginx:latest>                      #      Specifying the source (from) path in source (source) and destination as separate fields in one entry.
+      source: <src>
+      destination: <dst>
 
 kernel:                                         # [5] Specify a prebuilt kernel to use
   from: local                                   # [5a] Specify the source of a prebuilt kernel.
@@ -89,7 +90,7 @@ The fields of `bunnyfile` in more details:
 | 4a  | Base image or location containing a rootfs | no | `"scratch"`, `"local"`, `"OCI image"` | `"scratch"` |
 | 4b  | Path to rootfs file (relative to `from`) | yes, if `from == "local"` | file path | - |
 | 4c  | Type of the rootfs | no | `"raw"`, `"initrd"` | platform-dependent |
-| 4d  | Files from build context to include in rootfs | no | list of `local-path:rootfs-path`or list of specific Source, Destination entries | - |
+| 4d  | Files from local build context or other oci images to include in rootfs | no | list of `local-path:rootfs-path` or list of specific `from`, `source`, `destination` entries | - |
 | 5   | Prebuilt kernel information | yes | - | - |
 | 5a  | Location of the prebuilt kernel | yes | `"local"`, `"OCI image"` | - |
 | 5b  | Path to kernel binary (relative to `from`) | yes | file path | - |
@@ -146,12 +147,21 @@ field is useful. Users can choose (if they wish) a specific type of rootfs and
 
 #### The `include` field
 
-In this field users can define the files from the local build context that they
-want to include in the rootfs. It is equivalent to the `COPY` instruction in
-Dockerfile. The field accepts a list of entries with the following format:
+In this field users can define the files to include in the rootfs. There are two
+ways to do that. The first way supports only files from the local build context
+and has the following format:
 
 ```
 - <path_in the_local_build_context>:<path_inside_the_rootfs>
+```
+
+The second format is more verbose and allows users to include files from
+existing OCI images (similar to `COPY --from=` in Containerfile). The format is
+the following:
+```
+- from: <local_or_oci_image_reference>
+  source: <path_in the_local_build_context_or_oci_image>
+  destination: <path_inside_the_rootfs>
 ```
 
 > **_NOTE:_**  Except of the `bunnyfile`, `bunny` supports the Dockerfile-like

--- a/hops/generic.go
+++ b/hops/generic.go
@@ -77,13 +77,12 @@ func (i *GenericInfo) SupportsArch(_ string) bool {
 }
 
 func (i *GenericInfo) CreateRootfs(buildContext string) (llb.State, error) {
-	local := llb.Local(buildContext)
 	switch i.Rootfs.Type {
 	case "initrd":
-		contentState := FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
+		contentState := FilesLLB(i.Rootfs.Includes, buildContext, llb.Scratch())
 		return InitrdLLB(contentState), nil
 	case "raw":
-		return FilesLLB(i.Rootfs.Includes, local, llb.Scratch()), nil
+		return FilesLLB(i.Rootfs.Includes, buildContext, llb.Scratch()), nil
 	default:
 		// We should never reach this point
 		return llb.Scratch(), fmt.Errorf("Unsupported rootfs type %s", i.Rootfs.Type)
@@ -91,13 +90,12 @@ func (i *GenericInfo) CreateRootfs(buildContext string) (llb.State, error) {
 }
 
 func (i *GenericInfo) UpdateRootfs(buildContext string) (llb.State, error) {
-	local := llb.Local(buildContext)
 	base := llb.Image(i.Rootfs.From)
 	switch i.Rootfs.Type {
 	case "initrd":
 		return llb.Scratch(), fmt.Errorf("Can not update an initrd rootfs")
 	case "raw":
-		return FilesLLB(i.Rootfs.Includes, local, base), nil
+		return FilesLLB(i.Rootfs.Includes, buildContext, base), nil
 	default:
 		// We should never reach this point
 		return llb.Scratch(), fmt.Errorf("Unsupported rootfs type %s", i.Rootfs.Type)

--- a/hops/generic.go
+++ b/hops/generic.go
@@ -80,13 +80,10 @@ func (i *GenericInfo) CreateRootfs(buildContext string) (llb.State, error) {
 	local := llb.Local(buildContext)
 	switch i.Rootfs.Type {
 	case "initrd":
-		contentState, err := FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
-		if err != nil {
-			return llb.Scratch(), err
-		}
+		contentState := FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
 		return InitrdLLB(contentState), nil
 	case "raw":
-		return FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
+		return FilesLLB(i.Rootfs.Includes, local, llb.Scratch()), nil
 	default:
 		// We should never reach this point
 		return llb.Scratch(), fmt.Errorf("Unsupported rootfs type %s", i.Rootfs.Type)
@@ -100,7 +97,7 @@ func (i *GenericInfo) UpdateRootfs(buildContext string) (llb.State, error) {
 	case "initrd":
 		return llb.Scratch(), fmt.Errorf("Can not update an initrd rootfs")
 	case "raw":
-		return FilesLLB(i.Rootfs.Includes, local, base)
+		return FilesLLB(i.Rootfs.Includes, local, base), nil
 	default:
 		// We should never reach this point
 		return llb.Scratch(), fmt.Errorf("Unsupported rootfs type %s", i.Rootfs.Type)

--- a/hops/generic_test.go
+++ b/hops/generic_test.go
@@ -48,7 +48,7 @@ func TestGenericNew(t *testing.T) {
 			From:     "foo",
 			Path:     "bar",
 			Type:     "initrd",
-			Includes: []string{},
+			Includes: []FileToInclude{},
 		}
 
 		generic := NewGeneric(plat, rootfs)
@@ -91,7 +91,7 @@ func TestGenericGetRootfsType(t *testing.T) {
 			From:     "foo",
 			Path:     "bar",
 			Type:     "initrd",
-			Includes: []string{},
+			Includes: []FileToInclude{},
 		}
 
 		generic := NewGeneric(plat, rootfs)
@@ -146,7 +146,12 @@ func TestGenericCreateRootfs(t *testing.T) {
 			From:     "foo",
 			Path:     "bar",
 			Type:     "raw",
-			Includes: []string{"foo:bar"},
+			Includes: []FileToInclude{
+				{
+					Src: "foo",
+					Dst: "bar",
+				},
+			},
 		}
 
 		generic := NewGeneric(plat, rootfs)
@@ -186,7 +191,16 @@ func TestGenericCreateRootfs(t *testing.T) {
 			From:     "foo",
 			Path:     "bar",
 			Type:     "initrd",
-			Includes: []string{"foo:bar", "ka"},
+			Includes: []FileToInclude{
+				{
+					Src: "foo",
+					Dst: "bar",
+				},
+				{
+					Src: "ka",
+					Dst: "ka",
+				},
+			},
 		}
 
 		generic := NewGeneric(plat, rootfs)
@@ -247,24 +261,6 @@ func TestGenericCreateRootfs(t *testing.T) {
 		toolDgst := tmp.Inputs[0].Digest
 		require.Equal(t, m[toolDgst], arr[0])
 	})
-	t.Run("With raw rootfs type and invalid files structure", func(t *testing.T) {
-		plat := Platform{
-			Version: "1.0",
-			Monitor: "foo",
-			Arch:    "bar",
-		}
-		rootfs := Rootfs{
-			From:     "foo",
-			Path:     "bar",
-			Type:     "initrd",
-			Includes: []string{":bar", "ka"},
-		}
-
-		generic := NewGeneric(plat, rootfs)
-		_, err := generic.CreateRootfs("context")
-		require.Error(t, err)
-		require.ErrorContains(t, err, "Invalid format of the file")
-	})
 	t.Run("Invalid rootfs type", func(t *testing.T) {
 		plat := Platform{
 			Version: "1.0",
@@ -275,7 +271,12 @@ func TestGenericCreateRootfs(t *testing.T) {
 			From:     "foo",
 			Path:     "bar",
 			Type:     "qwe",
-			Includes: []string{"foo:bar", "ka"},
+			Includes: []FileToInclude{
+				{
+					Src: "foo",
+					Dst: "bar",
+				},
+			},
 		}
 
 		generic := NewGeneric(plat, rootfs)

--- a/hops/llb.go
+++ b/hops/llb.go
@@ -28,11 +28,16 @@ const (
 
 // Create a LLB State that simply copies all the files in the include list inside
 // an empty image
-func FilesLLB(fileList []FileToInclude, fromState llb.State, toState llb.State) llb.State {
+func FilesLLB(fileList []FileToInclude, buildContext string, toState llb.State) llb.State {
 	retState := llb.Scratch()
+	local := llb.Local(buildContext)
 	for i, file := range fileList {
 		var aCopy PackCopies
 
+		fromState := local
+		if file.From != "" && file.From != "local" {
+			fromState = llb.Image(file.From)
+		}
 		aCopy.SrcState = fromState
 		aCopy.SrcPath = file.Src
 		aCopy.DstPath = file.Dst

--- a/hops/llb.go
+++ b/hops/llb.go
@@ -15,7 +15,6 @@
 package hops
 
 import (
-	"fmt"
 	"runtime"
 	"strings"
 
@@ -29,22 +28,14 @@ const (
 
 // Create a LLB State that simply copies all the files in the include list inside
 // an empty image
-func FilesLLB(fileList []string, fromState llb.State, toState llb.State) (llb.State, error) {
+func FilesLLB(fileList []FileToInclude, fromState llb.State, toState llb.State) llb.State {
 	retState := llb.Scratch()
 	for i, file := range fileList {
 		var aCopy PackCopies
 
-		parts := strings.Split(file, ":")
 		aCopy.SrcState = fromState
-		aCopy.SrcPath = parts[0]
-		// If user did not define destination path, use the same as the source
-		aCopy.DstPath = parts[0]
-		if len(parts) < 1 || len(parts) > 2 || len(parts[0]) == 0 {
-			return llb.Scratch(), fmt.Errorf("Invalid format of the file list to copy")
-		}
-		if len(parts) == 2 && len(parts[1]) > 0 {
-			aCopy.DstPath = parts[1]
-		}
+		aCopy.SrcPath = file.Src
+		aCopy.DstPath = file.Dst
 		if i == 0 {
 			retState = CopyLLB(toState, aCopy)
 		} else {
@@ -52,7 +43,7 @@ func FilesLLB(fileList []string, fromState llb.State, toState llb.State) (llb.St
 		}
 	}
 
-	return retState, nil
+	return retState
 }
 
 // Create a LLB State that constructs a cpio file with the data in the content

--- a/hops/llb_test.go
+++ b/hops/llb_test.go
@@ -29,10 +29,14 @@ func TestLLBFiles(t *testing.T) {
 	t.Run("Single file", func(t *testing.T) {
 		src := llb.Local("context")
 		dst := llb.Scratch()
-		files := []string{"foo1"}
+		files := []FileToInclude{
+			{
+				Src: "foo1",
+				Dst: "foo1",
+			},
+		}
 
-		state, err := FilesLLB(files, src, dst)
-		require.NoError(t, err)
+		state := FilesLLB(files, src, dst)
 		def, err := state.Marshal(context.TODO())
 
 		require.NoError(t, err)
@@ -62,10 +66,18 @@ func TestLLBFiles(t *testing.T) {
 	t.Run("Multiple files", func(t *testing.T) {
 		src := llb.Local("context")
 		dst := llb.Image("foo")
-		files := []string{"foo1:bar1", "foo2:bar2"}
+		files := []FileToInclude{
+			{
+				Src: "foo1",
+				Dst: "bar1",
+			},
+			{
+				Src: "foo2",
+				Dst: "bar2",
+			},
+		}
 
-		state, err := FilesLLB(files, src, dst)
-		require.NoError(t, err)
+		state := FilesLLB(files, src, dst)
 		def, err := state.Marshal(context.TODO())
 
 		require.NoError(t, err)
@@ -103,36 +115,9 @@ func TestLLBFiles(t *testing.T) {
 	t.Run("Empty files list", func(t *testing.T) {
 		src := llb.Local("context")
 		dst := llb.Scratch()
-		files := []string{}
+		files := []FileToInclude{}
 
-		state, err := FilesLLB(files, src, dst)
-		require.NoError(t, err)
-		def, err := state.Marshal(context.TODO())
-
-		require.NoError(t, err)
-		_, arr := parseDef(t, def.Def)
-		require.Equal(t, 0, len(arr))
-	})
-	t.Run("Invalid file list no dest", func(t *testing.T) {
-		src := llb.Local("context")
-		dst := llb.Scratch()
-		files := []string{":foo"}
-
-		state, err := FilesLLB(files, src, dst)
-		require.EqualError(t, err, "Invalid format of the file list to copy")
-		def, err := state.Marshal(context.TODO())
-
-		require.NoError(t, err)
-		_, arr := parseDef(t, def.Def)
-		require.Equal(t, 0, len(arr))
-	})
-	t.Run("Invalid file list multiple sources", func(t *testing.T) {
-		src := llb.Local("context")
-		dst := llb.Scratch()
-		files := []string{"foo:a:b"}
-
-		state, err := FilesLLB(files, src, dst)
-		require.EqualError(t, err, "Invalid format of the file list to copy")
+		state := FilesLLB(files, src, dst)
 		def, err := state.Marshal(context.TODO())
 
 		require.NoError(t, err)

--- a/hops/llb_test.go
+++ b/hops/llb_test.go
@@ -27,7 +27,6 @@ import (
 
 func TestLLBFiles(t *testing.T) {
 	t.Run("Single file", func(t *testing.T) {
-		src := llb.Local("context")
 		dst := llb.Scratch()
 		files := []FileToInclude{
 			{
@@ -36,7 +35,7 @@ func TestLLBFiles(t *testing.T) {
 			},
 		}
 
-		state := FilesLLB(files, src, dst)
+		state := FilesLLB(files, "context", dst)
 		def, err := state.Marshal(context.TODO())
 
 		require.NoError(t, err)
@@ -64,7 +63,6 @@ func TestLLBFiles(t *testing.T) {
 		require.Equal(t, "/foo1", cp.Dest)
 	})
 	t.Run("Multiple files", func(t *testing.T) {
-		src := llb.Local("context")
 		dst := llb.Image("foo")
 		files := []FileToInclude{
 			{
@@ -77,7 +75,7 @@ func TestLLBFiles(t *testing.T) {
 			},
 		}
 
-		state := FilesLLB(files, src, dst)
+		state := FilesLLB(files, "context", dst)
 		def, err := state.Marshal(context.TODO())
 
 		require.NoError(t, err)
@@ -113,11 +111,10 @@ func TestLLBFiles(t *testing.T) {
 		require.Equal(t, "docker-image://docker.io/library/foo:latest", d.Identifier)
 	})
 	t.Run("Empty files list", func(t *testing.T) {
-		src := llb.Local("context")
 		dst := llb.Scratch()
 		files := []FileToInclude{}
 
-		state := FilesLLB(files, src, dst)
+		state := FilesLLB(files, "context", dst)
 		def, err := state.Marshal(context.TODO())
 
 		require.NoError(t, err)

--- a/hops/package.go
+++ b/hops/package.go
@@ -39,11 +39,16 @@ type Platform struct {
 	Arch      string `yaml:"architecture"`
 }
 
+type FileToInclude struct {
+	Src string `yaml:"source"`
+	Dst string `yaml:"destination"`
+}
+
 type Rootfs struct {
-	From     string   `yaml:"from"`
-	Path     string   `yaml:"path"`
-	Type     string   `yaml:"type"`
-	Includes []string `yaml:"include"`
+	From     string          `yaml:"from"`
+	Path     string          `yaml:"path"`
+	Type     string          `yaml:"type"`
+	Includes []FileToInclude `yaml:"include"`
 }
 
 type Kernel struct {

--- a/hops/package.go
+++ b/hops/package.go
@@ -40,8 +40,9 @@ type Platform struct {
 }
 
 type FileToInclude struct {
-	Src string `yaml:"source"`
-	Dst string `yaml:"destination"`
+	From string `yaml:"from"`
+	Src  string `yaml:"source"`
+	Dst  string `yaml:"destination"`
 }
 
 type Rootfs struct {

--- a/hops/package_test.go
+++ b/hops/package_test.go
@@ -148,7 +148,12 @@ func TestPackHandleRootfs(t *testing.T) {
 		r := Rootfs{
 			From:     "local",
 			Path:     "rootfs",
-			Includes: []string{"foo:bar"},
+			Includes: []FileToInclude{
+				{
+					Src: "foo",
+					Dst: "bar",
+				},
+			},
 		}
 		f := NewGeneric(p, r)
 
@@ -171,7 +176,12 @@ func TestPackHandleRootfs(t *testing.T) {
 		}
 		r := Rootfs{
 			From:     "scratch",
-			Includes: []string{"foo:bar"},
+			Includes: []FileToInclude{
+				{
+					Src: "foo",
+					Dst: "bar",
+				},
+			},
 		}
 		f := NewUnikraft(p, r)
 
@@ -198,7 +208,12 @@ func TestPackHandleRootfs(t *testing.T) {
 		r := Rootfs{
 			From:     "",
 			Type:     "raw",
-			Includes: []string{"foo:bar"},
+			Includes: []FileToInclude{
+				{
+					Src: "foo",
+					Dst: "bar",
+				},
+			},
 		}
 		f := NewGeneric(p, r)
 
@@ -929,7 +944,12 @@ func TestPackToPack(t *testing.T) {
 			},
 			Rootfs: Rootfs{
 				From:     "scratch",
-				Includes: []string{"foo:bar"},
+				Includes: []FileToInclude{
+					{
+						Src: "foo",
+						Dst: "bar",
+					},
+				},
 			},
 			Cmd: []string{"cmd"},
 		}
@@ -986,7 +1006,12 @@ func TestPackToPack(t *testing.T) {
 			},
 			Rootfs: Rootfs{
 				From:     "scratch",
-				Includes: []string{"foo:bar"},
+				Includes: []FileToInclude{
+					{
+						Src: "foo",
+						Dst: "bar",
+					},
+				},
 			},
 			Cmd: []string{"cmd"},
 		}
@@ -1171,7 +1196,12 @@ func TestPackToPack(t *testing.T) {
 			},
 			Rootfs: Rootfs{
 				From:     "scratch",
-				Includes: []string{"foo:bar"},
+				Includes: []FileToInclude{
+					{
+						Src: "foo",
+						Dst: "bar",
+					},
+				},
 			},
 			Cmd: []string{"cmd"},
 		}
@@ -1251,26 +1281,6 @@ func TestPackToPack(t *testing.T) {
 	//	require.ErrorContains(t, err, "unikraft does not support raw rootfs")
 	//	require.Nil(t, i)
 	// })
-	t.Run("Invalid Rootfs from scratch and wrong includes format", func(t *testing.T) {
-		hops := &Hops{
-			Platform: Platform{
-				Framework: "rumprun",
-				Monitor:   "qemu",
-			},
-			Kernel: Kernel{
-				From: "local",
-				Path: "kernel",
-			},
-			Rootfs: Rootfs{
-				From:     "scratch",
-				Includes: []string{":bar"},
-			},
-			Cmd: []string{"cmd"},
-		}
-		i, err := ToPack(hops, "context")
-		require.ErrorContains(t, err, "Error handling rootfs entry")
-		require.Nil(t, i)
-	})
 	t.Run("Invalid empty Kernel", func(t *testing.T) {
 		hops := &Hops{
 			Platform: Platform{

--- a/hops/unikraft.go
+++ b/hops/unikraft.go
@@ -90,13 +90,10 @@ func (i *UnikraftInfo) CreateRootfs(buildContext string) (llb.State, error) {
 	local := llb.Local(buildContext)
 	switch i.Rootfs.Type {
 	case "initrd":
-		contentState, err := FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
-		if err != nil {
-			return llb.Scratch(), err
-		}
+		contentState := FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
 		return InitrdLLB(contentState), nil
 	case "raw":
-		return FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
+		return FilesLLB(i.Rootfs.Includes, local, llb.Scratch()), nil
 	default:
 		// We should never reach this point
 		return llb.Scratch(), fmt.Errorf("Unsupported rootfs type")
@@ -110,7 +107,7 @@ func (i *UnikraftInfo) UpdateRootfs(buildContext string) (llb.State, error) {
 	case "initrd":
 		return llb.Scratch(), fmt.Errorf("Can not update an initrd rootfs")
 	case "raw":
-		return FilesLLB(i.Rootfs.Includes, local, base)
+		return FilesLLB(i.Rootfs.Includes, local, base), nil
 	default:
 		// We should never reach this point
 		return llb.Scratch(), fmt.Errorf("Unsupported rootfs type")

--- a/hops/unikraft.go
+++ b/hops/unikraft.go
@@ -87,13 +87,12 @@ func (i *UnikraftInfo) SupportsArch(arch string) bool {
 }
 
 func (i *UnikraftInfo) CreateRootfs(buildContext string) (llb.State, error) {
-	local := llb.Local(buildContext)
 	switch i.Rootfs.Type {
 	case "initrd":
-		contentState := FilesLLB(i.Rootfs.Includes, local, llb.Scratch())
+		contentState := FilesLLB(i.Rootfs.Includes, buildContext, llb.Scratch())
 		return InitrdLLB(contentState), nil
 	case "raw":
-		return FilesLLB(i.Rootfs.Includes, local, llb.Scratch()), nil
+		return FilesLLB(i.Rootfs.Includes, buildContext, llb.Scratch()), nil
 	default:
 		// We should never reach this point
 		return llb.Scratch(), fmt.Errorf("Unsupported rootfs type")
@@ -101,13 +100,12 @@ func (i *UnikraftInfo) CreateRootfs(buildContext string) (llb.State, error) {
 }
 
 func (i *UnikraftInfo) UpdateRootfs(buildContext string) (llb.State, error) {
-	local := llb.Local(buildContext)
 	base := llb.Image(i.Rootfs.From)
 	switch i.Rootfs.Type {
 	case "initrd":
 		return llb.Scratch(), fmt.Errorf("Can not update an initrd rootfs")
 	case "raw":
-		return FilesLLB(i.Rootfs.Includes, local, base), nil
+		return FilesLLB(i.Rootfs.Includes, buildContext, base), nil
 	default:
 		// We should never reach this point
 		return llb.Scratch(), fmt.Errorf("Unsupported rootfs type")

--- a/hops/unikraft_test.go
+++ b/hops/unikraft_test.go
@@ -48,7 +48,7 @@ func TestUnikraftNew(t *testing.T) {
 			From:     "foo",
 			Path:     "bar",
 			Type:     "raw",
-			Includes: []string{},
+			Includes: []FileToInclude{},
 		}
 
 		unikraft := NewUnikraft(plat, rootfs)
@@ -91,7 +91,7 @@ func TestUnikraftGetRootfsType(t *testing.T) {
 			From:     "foo",
 			Path:     "bar",
 			Type:     "raw",
-			Includes: []string{},
+			Includes: []FileToInclude{},
 		}
 
 		unikraft := NewUnikraft(plat, rootfs)
@@ -168,7 +168,12 @@ func TestUnikraftCreateRootfs(t *testing.T) {
 		rootfs := Rootfs{
 			From:     "scratch",
 			Type:     "initrd",
-			Includes: []string{"foo:bar"},
+			Includes: []FileToInclude{
+				{
+					Src: "foo",
+					Dst: "bar",
+				},
+			},
 		}
 
 		unikraft := NewUnikraft(plat, rootfs)
@@ -218,24 +223,6 @@ func TestUnikraftCreateRootfs(t *testing.T) {
 		// the tools
 		toolDgst := tmp.Inputs[0].Digest
 		require.Equal(t, m[toolDgst], arr[0])
-	})
-	t.Run("Invalid files structure", func(t *testing.T) {
-		plat := Platform{
-			Version: "1.0",
-			Monitor: "foo",
-			Arch:    "bar",
-		}
-		rootfs := Rootfs{
-			From:     "foo",
-			Path:     "bar",
-			Type:     "initrd",
-			Includes: []string{":bar", "ka"},
-		}
-
-		unikraft := NewUnikraft(plat, rootfs)
-		_, err := unikraft.CreateRootfs("context")
-		require.Error(t, err)
-		require.ErrorContains(t, err, "Invalid format of the file")
 	})
 }
 

--- a/hops/validate.go
+++ b/hops/validate.go
@@ -16,7 +16,6 @@ package hops
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/go-version"
 )
@@ -84,13 +83,6 @@ func ValidateRootfs(rootfs Rootfs) error {
 
 	if len(rootfs.Includes) > 0 && rootfs.From != "" && rootfs.From != "scratch" && rootfs.Type != "raw" {
 		return fmt.Errorf("Adding files to an existing non-raw rootfs is not yet supported")
-	}
-
-	for _, file := range rootfs.Includes {
-		parts := strings.Split(file, ":")
-		if len(parts) < 1 || len(parts[0]) == 0 {
-			return fmt.Errorf("Invalid syntax in rootf's include. An entry can not have its first part empty")
-		}
 	}
 
 	return nil

--- a/hops/validate_test.go
+++ b/hops/validate_test.go
@@ -196,12 +196,6 @@ func TestValidateBunnyfileRootfs(t *testing.T) {
 			expectError: true,
 			errorText:   "Adding files to an existing non-raw rootfs is not yet supported",
 		},
-		{
-			name:        "Invalid include with no source",
-			input:       "///:bar",
-			expectError: true,
-			errorText:   "Invalid syntax in rootf's include",
-		},
 	}
 
 	for _, tc := range tests {
@@ -212,7 +206,19 @@ func TestValidateBunnyfileRootfs(t *testing.T) {
 			rfs.Path = fields[1]
 			rfs.Type = fields[2]
 			if fields[3] != "" {
-				rfs.Includes = []string{fields[3]}
+				ffields := strings.Split(fields[3], ":")
+				require.GreaterOrEqual(t, len(ffields), 1)
+				require.LessOrEqual(t, len(ffields), 2)
+				dst := ffields[0]
+				if len(ffields) == 2 {
+					dst = ffields[1]
+				}
+				rfs.Includes = []FileToInclude{
+					{
+						Src: ffields[0],
+						Dst: dst,
+					},
+				}
 			}
 			err := ValidateRootfs(rfs)
 			if tc.expectError {


### PR DESCRIPTION
Allow users to define files that they want to include in the rootfs from other OCI images, with the following format:
```
- from: <oci_image_reference>
  source: <path_inside_the_image>
  destination: <path_in_the_rootfs>
 ```
 
 The from field can have either the special value `local` or a reference to an OCI image. In case of `local` the locla build context will be used to search for the `source` of the file. In case `from` is omitted then the locla build context will be used.
 
 Furthermore, keep the previous format of `<src>:<dst>` but only for local files and change the way bunny treats this entry, storing the results always in the respective struct to avoid issues with ':' as delimiter and simplify the code.
