### PR TITLE
Get and store the base OCI image correctly

### DIFF
--- a/hops/image_config.go
+++ b/hops/image_config.go
@@ -28,14 +28,14 @@ import (
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func getBaseConfig(ctx context.Context, c client.Client, ref string, mon string) (ocispecs.ImageConfig, error) {
+func getBaseConfig(ctx context.Context, c client.Client, ref string, mon string) (ocispecs.Image, error) {
 	if ref == "" || ref == "scratch" {
-		return ocispecs.ImageConfig{}, nil
+		return ocispecs.Image{}, nil
 	}
 
 	baseRef, err := reference.ParseNormalizedNamed(ref)
 	if err != nil {
-		return ocispecs.ImageConfig{}, fmt.Errorf("failed to parse image name %s: %v", ref, err)
+		return ocispecs.Image{}, fmt.Errorf("failed to parse image name %s: %v", ref, err)
 	}
 	baseImageName := reference.TagNameOnly(baseRef).String()
 
@@ -56,13 +56,13 @@ func getBaseConfig(ctx context.Context, c client.Client, ref string, mon string)
 			},
 		})
 	if err != nil {
-		return ocispecs.ImageConfig{}, fmt.Errorf("failed to get image config from %s: %v", baseImageName, err)
+		return ocispecs.Image{}, fmt.Errorf("failed to get image config from %s: %v", baseImageName, err)
 	}
 
-	var cfg ocispecs.ImageConfig
+	var cfg ocispecs.Image
 	err = json.Unmarshal(config, &cfg)
 	if err != nil {
-		return ocispecs.ImageConfig{}, fmt.Errorf("failed to unmarshal image config of %s: %v", baseImageName, err)
+		return ocispecs.Image{}, fmt.Errorf("failed to unmarshal image config of %s: %v", baseImageName, err)
 	}
 
 	return cfg, nil

--- a/hops/parse_file.go
+++ b/hops/parse_file.go
@@ -141,19 +141,19 @@ func hopsToPack(ctx context.Context, fileBytes []byte, buildContext string, c cl
 	}
 
 	// Get the OCI Image config of the base Image if there is any
-	baseConfig, err := getBaseConfig(ctx, c, packInst.BaseRef, packInst.Annots["com.urunc.unikernel.hypervisor"])
+	baseImg, err := getBaseConfig(ctx, c, packInst.BaseRef, packInst.Annots["com.urunc.unikernel.hypervisor"])
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get OCI config of base image %s: %w", packInst.BaseRef, err)
 	}
 
 	if len(packInst.Img.Config.Cmd) > 0 {
-		baseConfig.Cmd = packInst.Img.Config.Cmd
+		baseImg.Config.Cmd = packInst.Img.Config.Cmd
 	}
 	if len(packInst.Img.Config.Entrypoint) > 0 {
-		baseConfig.Entrypoint = packInst.Img.Config.Entrypoint
+		baseImg.Config.Entrypoint = packInst.Img.Config.Entrypoint
 	}
-	baseConfig.Env = append(baseConfig.Env, packInst.Img.Config.Env...)
-	packInst.Img.Config = baseConfig
+	baseImg.Config.Env = append(baseImg.Config.Env, packInst.Img.Config.Env...)
+	packInst.Img = baseImg
 
 	// Get the OCI Image config of the base Image if there is any
 	packInst.Img = updateImage(packInst.Img, packInst.Annots)


### PR DESCRIPTION
Fix getBaseConfig to return the base Image struct and not only ImageConfig.