### PR TITLE
fix(annotations): strictly prepend b64: to base64 encoded annotations

### DIFF
--- a/hops/package.go
+++ b/hops/package.go
@@ -368,8 +368,8 @@ func PackLLB(instr PackInstructions) (*llb.Definition, error) {
 
 	// Create urunc.json file, since annotations do not reach urunc
 	for annot, val := range instr.Annots {
-		encoded := base64.StdEncoding.EncodeToString([]byte(val))
-		uruncJSON[annot] = string(encoded)
+		encoded := "b64:" + base64.StdEncoding.EncodeToString([]byte(val))
+		uruncJSON[annot] = encoded
 	}
 	uruncJSONBytes, err := json.Marshal(uruncJSON)
 	if err != nil {

--- a/hops/package_test.go
+++ b/hops/package_test.go
@@ -1337,8 +1337,8 @@ func TestPackLLB(t *testing.T) {
 		err = json.Unmarshal(mkfile.Data, &annotJSON)
 		require.NoError(t, err)
 		for an, val := range instr.Annots {
-			encoded := base64.StdEncoding.EncodeToString([]byte(val))
-			require.Equal(t, string(encoded), annotJSON[an])
+			encoded := "b64:" + base64.StdEncoding.EncodeToString([]byte(val))
+			require.Equal(t, encoded, annotJSON[an])
 		}
 	})
 	t.Run("Base scratch no annots no copies", func(t *testing.T) {
@@ -1425,8 +1425,8 @@ func TestPackLLB(t *testing.T) {
 		err = json.Unmarshal(mkfile.Data, &annotJSON)
 		require.NoError(t, err)
 		for an, val := range instr.Annots {
-			encoded := base64.StdEncoding.EncodeToString([]byte(val))
-			require.Equal(t, string(encoded), annotJSON[an])
+			encoded := "b64:" + base64.StdEncoding.EncodeToString([]byte(val))
+			require.Equal(t, encoded, annotJSON[an])
 		}
 
 		c1 := arr[3]


### PR DESCRIPTION
## The Problem
`bunny` currently blindly Base64-encodes all OCI annotations when writing `urunc.json`. This makes it impossible for `urunc` to safely distinguish between intended Base64 payloads and standard plaintext config labels without relying on unsafe heuristics.
## The Solution
This PR prepends a strict `"b64:"` prefix to all encoded annotations generated in `hops/package.go`. 
This enables `urunc`'s new strict parser to safely decode these payloads without the risk of silently corrupting plaintext labels that happen to look like valid base64.

context : https://github.com/urunc-dev/urunc/issues/771